### PR TITLE
NPE in conversion between Aether and Maven artifact

### DIFF
--- a/src/main/java/org/reficio/p2/utils/BundleUtils.java
+++ b/src/main/java/org/reficio/p2/utils/BundleUtils.java
@@ -22,6 +22,8 @@ import aQute.lib.osgi.Analyzer;
 import aQute.lib.osgi.Jar;
 import org.apache.felix.bundleplugin.BundlePlugin;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.sonatype.aether.artifact.Artifact;
 
 import java.io.IOException;
@@ -45,12 +47,18 @@ public class BundleUtils extends BundlePlugin {
     }
 
     public static org.apache.maven.artifact.Artifact aetherToMavenArtifactBasic(Artifact artifact) {
-        DefaultArtifact mavenArtifact = new DefaultArtifact(
-                artifact.getGroupId(),
+    	String type = artifact.getProperty("type", "");
+    	String scope = org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
+    	String classifier = null;
+    	ArtifactHandler artifactHandler = new DefaultArtifactHandler(type);
+    	
+		DefaultArtifact mavenArtifact = new DefaultArtifact(
+				artifact.getGroupId(),
                 artifact.getArtifactId(),
-                artifact.getVersion(),
-                null, null, null, null);
-        return mavenArtifact;
+                artifact.getVersion(), 
+                scope, type, classifier, artifactHandler);
+        
+		return mavenArtifact;
     }
 
     public String getBundleSymbolicName(Artifact artifact) {


### PR DESCRIPTION
Hi,

I tried the plugin to build a simple update site with following pom:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001 XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>

  <groupId>org.reficio.rcp</groupId>
  <artifactId>example-p2-site</artifactId>
  <packaging>pom</packaging>
  <version>1.0.0</version>

  <build>
    <plugins>
      <plugin>
        <groupId>org.reficio</groupId>
        <artifactId>p2-maven-plugin</artifactId>
        <version>1.0.0-SNAPSHOT</version>
        <executions>
          <execution>
            <id>generate-p2-site</id>
            <phase>compile</phase>
            <goals>
              <goal>site</goal>
            </goals>
            <configuration>
              <artifacts>
                <!-- specify your depencies here -->
                <!-- groupId:artifactId:version -->
                <artifact>org.scalatest:scalatest_2.9.2:1.8</artifact>
              </artifacts>
            </configuration>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
</project>
```

And it failed with following exception:

```
[ERROR] Failed to execute goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) on project example-p2-site: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) on project example-p2-site: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:225)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
     at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
     at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
     at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
     at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
     at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
     at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
     at java.lang.reflect.Method.invoke(Method.java:597)
     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
     at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
     at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException
     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:110)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
     ... 19 more
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
     at org.reficio.p2.P2Mojo.execute(P2Mojo.java:199)
     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
     ... 20 more
Caused by: java.lang.NullPointerException
     at org.apache.maven.artifact.DefaultArtifact.<init>(DefaultArtifact.java:116)
     at org.apache.maven.artifact.DefaultArtifact.<init>(DefaultArtifact.java:87)
     at org.reficio.p2.utils.BundleUtils.aetherToMavenArtifactBasic(BundleUtils.java:48)
     at org.reficio.p2.utils.BundleUtils.getBundleVersion(BundleUtils.java:61)
     at org.reficio.p2.utils.BundleWrapper.setBundleOptions(BundleWrapper.java:191)
     at org.reficio.p2.utils.BundleWrapper.initializeAnalyzer(BundleWrapper.java:168)
     at org.reficio.p2.utils.BundleWrapper.handleVanillaJarWrap(BundleWrapper.java:120)
     at org.reficio.p2.utils.BundleWrapper.doWrap(BundleWrapper.java:106)
     at org.reficio.p2.utils.BundleWrapper.wrapArtifacts(BundleWrapper.java:98)
     at org.reficio.p2.utils.BundleWrapper.execute(BundleWrapper.java:63)
     at org.reficio.p2.P2Mojo.executeBndWrapper(P2Mojo.java:218)
     at org.reficio.p2.P2Mojo.execute(P2Mojo.java:192)
     ... 21 more
```

I only changed the `org.reficio.p2.utils.BundleUtils.aetherToMavenArtifactBasic(BundleUtils.java:48)` and now it seems to work. However, I have never done any maven plugin dev so I have no idea if this is the way to handle the conversion.

Thanks for the plugin, btw! :-)

Filip

Here is the full output:

```

[krikava@kathmandu:fr.unice.i3s.sigma.targetplatform (master)]$ mvn clean compile
[INFO] Scanning for projects...
[INFO]                                                                        
[INFO] ------------------------------------------------------------------------
[INFO] Building example-p2-site 1.0.0
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ example-p2-site ---
[INFO]
[INFO] --- p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) @ example-p2-site ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.641s
[INFO] Finished at: Wed Aug 01 23:08:42 CEST 2012
[INFO] Final Memory: 6M/81M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) on project example-p2-site: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[krikava@kathmandu:fr.unice.i3s.sigma.targetplatform (master)]$ mvn -X clean compile
Apache Maven 3.0.3 (r1075438; 2011-02-28 18:31:09+0100)
Maven home: /usr/share/maven
Java version: 1.6.0_33, vendor: Apple Inc.
Java home: /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
Default locale: en_US, platform encoding: MacRoman
OS name: "mac os x", version: "10.7.4", arch: "x86_64", family: "mac"
[INFO] Error stacktraces are turned on.
[DEBUG] Reading global settings from /usr/share/maven/conf/settings.xml
[DEBUG] Reading user settings from /Users/krikava/.m2/settings.xml
[DEBUG] Using local repository at /Users/krikava/.m2/repository
[DEBUG] Using manager EnhancedLocalRepositoryManager with priority 10 for /Users/krikava/.m2/repository
[INFO] Scanning for projects...
[DEBUG] Extension realms for project org.reficio.rcp:example-p2-site:pom:1.0.0: (none)
[DEBUG] Looking up lifecyle mappings for packaging pom from ClassRealm[plexus.core, parent: null]
[DEBUG] === REACTOR BUILD PLAN ================================================
[DEBUG] Project: org.reficio.rcp:example-p2-site:pom:1.0.0
[DEBUG] Tasks:   [clean, compile]
[DEBUG] Style:   Regular
[DEBUG] =======================================================================
[INFO]                                                                        
[INFO] ------------------------------------------------------------------------
[INFO] Building example-p2-site 1.0.0
[INFO] ------------------------------------------------------------------------
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] === PROJECT BUILD PLAN ================================================
[DEBUG] Project:       org.reficio.rcp:example-p2-site:1.0.0
[DEBUG] Dependencies (collect): [runtime]
[DEBUG] Dependencies (resolve): [runtime]
[DEBUG] Repositories (dependencies): [reficio (http://repo.reficio.org/maven/, releases+snapshots), sonatype.release (https://oss.sonatype.org/content/repositories/releases/, releases), sonatype.snapshot (https://oss.sonatype.org/content/repositories/snapshots, releases+snapshots), central (http://repo1.maven.org/maven2, releases)]
[DEBUG] Repositories (plugins)     : [central (http://repo1.maven.org/maven2, releases)]
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-clean-plugin:2.4.1:clean (default-clean)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <directory default-value="${project.build.directory}"/>
  <excludeDefaultDirectories default-value="false">${clean.excludeDefaultDirectories}</excludeDefaultDirectories>
  <failOnError default-value="true">${maven.clean.failOnError}</failOnError>
  <followSymLinks default-value="false">${clean.followSymLinks}</followSymLinks>
  <outputDirectory default-value="${project.build.outputDirectory}"/>
  <reportDirectory default-value="${project.reporting.outputDirectory}"/>
  <skip default-value="false">${clean.skip}</skip>
  <testOutputDirectory default-value="${project.build.testOutputDirectory}"/>
  <verbose>${clean.verbose}</verbose>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <artifacts>
    <artifact>org.apache.commons:commons-lang3:3.1</artifact>
    <artifact>org.scalatest:scalatest_2.9.2:1.8</artifact>
  </artifacts>
  <buildDirectory>${project.build.directory}</buildDirectory>
  <compressSite default-value="true"/>
  <destinationDirectory>${project.build.directory}/repository</destinationDirectory>
  <forkedProcessTimeoutInSeconds default-value="0">${p2.timeout}</forkedProcessTimeoutInSeconds>
  <pedantic default-value="false"/>
  <project>${project}</project>
  <projectRepos default-value="${project.remoteProjectRepositories}"/>
  <repoSession default-value="${repositorySystemSession}"/>
  <session>${session}</session>
</configuration>
[DEBUG] =======================================================================
[DEBUG] org.reficio.rcp:example-p2-site:pom:1.0.0
[INFO]
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ example-p2-site ---
[DEBUG] Created new class realm maven.api
[DEBUG] Importing foreign packages into class realm maven.api
[DEBUG]   Imported: org.apache.maven.wagon.events < plexus.core
[DEBUG]   Imported: org.sonatype.aether.transfer < plexus.core
[DEBUG]   Imported: org.apache.maven.exception < plexus.core
[DEBUG]   Imported: org.sonatype.aether.metadata < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.Xpp3Dom < plexus.core
[DEBUG]   Imported: org.sonatype.aether.collection < plexus.core
[DEBUG]   Imported: org.sonatype.aether.version < plexus.core
[DEBUG]   Imported: org.apache.maven.monitor < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.repository < plexus.core
[DEBUG]   Imported: org.apache.maven.repository < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.resource < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.logging < plexus.core
[DEBUG]   Imported: org.apache.maven.profiles < plexus.core
[DEBUG]   Imported: org.sonatype.aether.repository < plexus.core
[DEBUG]   Imported: org.apache.maven.classrealm < plexus.core
[DEBUG]   Imported: org.apache.maven.execution < plexus.core
[DEBUG]   Imported: org.sonatype.aether.artifact < plexus.core
[DEBUG]   Imported: org.sonatype.aether.spi < plexus.core
[DEBUG]   Imported: org.apache.maven.reporting < plexus.core
[DEBUG]   Imported: org.apache.maven.usability < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.container < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.component < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlSerializer < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.authentication < plexus.core
[DEBUG]   Imported: org.apache.maven.lifecycle < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.classworlds < plexus.core
[DEBUG]   Imported: org.sonatype.aether.graph < plexus.core
[DEBUG]   Imported: org.sonatype.aether.* < plexus.core
[DEBUG]   Imported: org.apache.maven.settings < plexus.core
[DEBUG]   Imported: org.codehaus.classworlds < plexus.core
[DEBUG]   Imported: org.sonatype.aether.impl < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.* < plexus.core
[DEBUG]   Imported: org.apache.maven.toolchain < plexus.core
[DEBUG]   Imported: org.sonatype.aether.deployment < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.observers < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlPullParserException < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlPullParser < plexus.core
[DEBUG]   Imported: org.apache.maven.configuration < plexus.core
[DEBUG]   Imported: org.apache.maven.cli < plexus.core
[DEBUG]   Imported: org.sonatype.aether.installation < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.context < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.authorization < plexus.core
[DEBUG]   Imported: org.apache.maven.project < plexus.core
[DEBUG]   Imported: org.apache.maven.rtinfo < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.lifecycle < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.configuration < plexus.core
[DEBUG]   Imported: org.apache.maven.artifact < plexus.core
[DEBUG]   Imported: org.apache.maven.model < plexus.core
[DEBUG]   Imported: org.apache.maven.* < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.proxy < plexus.core
[DEBUG]   Imported: org.sonatype.aether.resolution < plexus.core
[DEBUG]   Imported: org.apache.maven.plugin < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.* < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.personality < plexus.core
[DEBUG] Populating class realm maven.api
[DEBUG] org.apache.maven.plugins:maven-clean-plugin:jar:2.4.1:
[DEBUG]    org.apache.maven:maven-plugin-api:jar:2.0.6:compile
[DEBUG]    org.codehaus.plexus:plexus-utils:jar:2.0.5:compile
[DEBUG] Created new class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.4.1
[DEBUG] Importing foreign packages into class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.4.1
[DEBUG]   Imported:  < maven.api
[DEBUG] Populating class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.4.1
[DEBUG]   Included: org.apache.maven.plugins:maven-clean-plugin:jar:2.4.1
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:2.0.5
[DEBUG]   Excluded: org.apache.maven:maven-plugin-api:jar:2.0.6
[DEBUG] Configuring mojo org.apache.maven.plugins:maven-clean-plugin:2.4.1:clean from plugin realm ClassRealm[plugin>org.apache.maven.plugins:maven-clean-plugin:2.4.1, parent: sun.misc.Launcher$AppClassLoader@7a9664a1]
[DEBUG] Configuring mojo 'org.apache.maven.plugins:maven-clean-plugin:2.4.1:clean' with basic configurator -->
[DEBUG]   (f) directory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target
[DEBUG]   (f) excludeDefaultDirectories = false
[DEBUG]   (f) failOnError = true
[DEBUG]   (f) followSymLinks = false
[DEBUG]   (f) outputDirectory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/classes
[DEBUG]   (f) reportDirectory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/site
[DEBUG]   (f) skip = false
[DEBUG]   (f) testOutputDirectory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/test-classes
[DEBUG] -- end configuration --
[INFO] Deleting /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target
[INFO] Deleting file /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/source/plugins/commons-lang3-3.1.jar
[INFO] Deleting directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/source/plugins
[INFO] Deleting directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/source
[INFO] Deleting file /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/jars/scalatest_2.9.2-1.8.jar
[INFO] Deleting file /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/jars/scala-library-2.9.2.jar
[INFO] Deleting file /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/jars/commons-lang3-3.1.jar
[INFO] Deleting directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/jars
[INFO] Deleting directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target
[DEBUG] Skipping non-existing directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/classes
[DEBUG] Skipping non-existing directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/test-classes
[DEBUG] Skipping non-existing directory /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/site
[INFO]
[INFO] --- p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) @ example-p2-site ---
[DEBUG] org.reficio:p2-maven-plugin:jar:1.0.0-SNAPSHOT:
[DEBUG]    commons-io:commons-io:jar:2.1:compile
[DEBUG]    commons-collections:commons-collections:jar:3.2.1:compile
[DEBUG]    commons-lang:commons-lang:jar:2.6:compile
[DEBUG]    biz.aQute:bnd:jar:0.0.384:compile
[DEBUG]    org.apache.commons:commons-exec:jar:1.1:compile
[DEBUG]    org.twdata.maven:mojo-executor:jar:2.0:compile
[DEBUG]       org.apache.maven:maven-core:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-settings:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-settings-builder:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-repository-metadata:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-artifact:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-model-builder:jar:3.0:compile
[DEBUG]          org.apache.maven:maven-aether-provider:jar:3.0:runtime
[DEBUG]          org.sonatype.aether:aether-impl:jar:1.7:compile
[DEBUG]             org.sonatype.aether:aether-spi:jar:1.7:compile
[DEBUG]          org.sonatype.aether:aether-util:jar:1.7:compile
[DEBUG]          org.codehaus.plexus:plexus-interpolation:jar:1.14:compile
[DEBUG]          org.codehaus.plexus:plexus-classworlds:jar:2.2.3:compile
[DEBUG]          org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
[DEBUG]          org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
[DEBUG]             org.sonatype.plexus:plexus-cipher:jar:1.4:compile
[DEBUG]       org.apache.maven:maven-model:jar:3.0:compile
[DEBUG]       org.apache.maven:maven-plugin-api:jar:3.0:compile
[DEBUG]       org.codehaus.plexus:plexus-utils:jar:1.5.1:compile
[DEBUG]       org.sonatype.aether:aether-api:jar:1.7:compile
[DEBUG]       org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2:compile
[DEBUG]          org.sonatype.sisu:sisu-inject-bean:jar:1.4.2:compile
[DEBUG]             org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7:compile
[DEBUG]    org.apache.felix:maven-bundle-plugin:jar:2.3.6:compile
[DEBUG]       biz.aQute:bndlib:jar:1.50.0:compile
[DEBUG]       org.apache.felix:org.apache.felix.bundlerepository:jar:1.6.6:compile
[DEBUG]          org.easymock:easymock:jar:2.4:compile
[DEBUG]       org.apache.maven:maven-archiver:jar:2.4.1:compile
[DEBUG]          org.codehaus.plexus:plexus-archiver:jar:1.0:compile
[DEBUG]             org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
[DEBUG]                junit:junit:jar:3.8.1:compile
[DEBUG]                classworlds:classworlds:jar:1.1-alpha-2:compile
[DEBUG]             org.codehaus.plexus:plexus-io:jar:1.0:compile
[DEBUG]       org.apache.maven.shared:maven-dependency-tree:jar:1.2:compile
[DEBUG]          org.apache.maven:maven-project:jar:2.0.8:compile
[DEBUG]             org.apache.maven:maven-profile:jar:2.0.8:compile
[DEBUG]             org.apache.maven:maven-artifact-manager:jar:2.0.8:compile
[DEBUG]             org.apache.maven:maven-plugin-registry:jar:2.0.8:compile
[DEBUG]    org.eclipse.tycho.extras:tycho-p2-extras-plugin:jar:0.14.0:compile
[DEBUG]       org.eclipse.tycho:tycho-p2-facade:jar:0.14.0:compile
[DEBUG]          org.eclipse.tycho:org.eclipse.osgi:jar:3.8.0.v20120123-1419:compile
[DEBUG]          org.eclipse.tycho:tycho-core:jar:0.14.0:compile
[DEBUG]             org.eclipse.tycho:tycho-metadata-model:jar:0.14.0:compile
[DEBUG]                de.pdark:decentxml:jar:1.3:compile
[DEBUG]             org.eclipse.tycho:tycho-embedder-api:jar:0.14.0:compile
[DEBUG]                org.eclipse.tycho:org.eclipse.tycho.embedder.shared:jar:0.14.0:compile
[DEBUG]             org.eclipse.tycho:org.eclipse.tycho.core.shared:jar:0.14.0:compile
[DEBUG]          org.eclipse.tycho:sisu-equinox-embedder:jar:0.14.0:compile
[DEBUG]          org.eclipse.tycho:org.eclipse.tycho.p2.resolver.shared:jar:0.14.0:compile
[DEBUG]          org.eclipse.tycho:org.eclipse.tycho.p2.tools.shared:jar:0.14.0:compile
[DEBUG]       org.eclipse.tycho:sisu-equinox-launching:jar:0.14.0:compile
[DEBUG]          org.eclipse.tycho:sisu-equinox-api:jar:0.14.0:compile
[DEBUG] Created new class realm plugin>org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT
[DEBUG] Importing foreign packages into class realm plugin>org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT
[DEBUG]   Imported:  < maven.api
[DEBUG] Populating class realm plugin>org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT
[DEBUG]   Included: org.reficio:p2-maven-plugin:jar:1.0.0-SNAPSHOT
[DEBUG]   Included: commons-io:commons-io:jar:2.1
[DEBUG]   Included: commons-collections:commons-collections:jar:3.2.1
[DEBUG]   Included: commons-lang:commons-lang:jar:2.6
[DEBUG]   Included: biz.aQute:bnd:jar:0.0.384
[DEBUG]   Included: org.apache.commons:commons-exec:jar:1.1
[DEBUG]   Included: org.twdata.maven:mojo-executor:jar:2.0
[DEBUG]   Included: org.sonatype.aether:aether-util:jar:1.7
[DEBUG]   Included: org.codehaus.plexus:plexus-interpolation:jar:1.14
[DEBUG]   Included: org.codehaus.plexus:plexus-component-annotations:jar:1.5.5
[DEBUG]   Included: org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3
[DEBUG]   Included: org.sonatype.plexus:plexus-cipher:jar:1.4
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:1.5.1
[DEBUG]   Included: org.sonatype.sisu:sisu-inject-bean:jar:1.4.2
[DEBUG]   Included: org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7
[DEBUG]   Included: org.apache.felix:maven-bundle-plugin:jar:2.3.6
[DEBUG]   Included: biz.aQute:bndlib:jar:1.50.0
[DEBUG]   Included: org.apache.felix:org.apache.felix.bundlerepository:jar:1.6.6
[DEBUG]   Included: org.easymock:easymock:jar:2.4
[DEBUG]   Included: org.apache.maven:maven-archiver:jar:2.4.1
[DEBUG]   Included: org.codehaus.plexus:plexus-archiver:jar:1.0
[DEBUG]   Included: junit:junit:jar:3.8.1
[DEBUG]   Included: org.codehaus.plexus:plexus-io:jar:1.0
[DEBUG]   Included: org.apache.maven.shared:maven-dependency-tree:jar:1.2
[DEBUG]   Included: org.eclipse.tycho.extras:tycho-p2-extras-plugin:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:tycho-p2-facade:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:org.eclipse.osgi:jar:3.8.0.v20120123-1419
[DEBUG]   Included: org.eclipse.tycho:tycho-core:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:tycho-metadata-model:jar:0.14.0
[DEBUG]   Included: de.pdark:decentxml:jar:1.3
[DEBUG]   Included: org.eclipse.tycho:tycho-embedder-api:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:org.eclipse.tycho.embedder.shared:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:org.eclipse.tycho.core.shared:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:sisu-equinox-embedder:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:org.eclipse.tycho.p2.resolver.shared:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:org.eclipse.tycho.p2.tools.shared:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:sisu-equinox-launching:jar:0.14.0
[DEBUG]   Included: org.eclipse.tycho:sisu-equinox-api:jar:0.14.0
[DEBUG]   Excluded: org.apache.maven:maven-core:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-settings:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-settings-builder:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-repository-metadata:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-artifact:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-model-builder:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-aether-provider:jar:3.0
[DEBUG]   Excluded: org.sonatype.aether:aether-impl:jar:1.7
[DEBUG]   Excluded: org.sonatype.aether:aether-spi:jar:1.7
[DEBUG]   Excluded: org.codehaus.plexus:plexus-classworlds:jar:2.2.3
[DEBUG]   Excluded: org.apache.maven:maven-model:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-plugin-api:jar:3.0
[DEBUG]   Excluded: org.sonatype.aether:aether-api:jar:1.7
[DEBUG]   Excluded: org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2
[DEBUG]   Excluded: org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1
[DEBUG]   Excluded: classworlds:classworlds:jar:1.1-alpha-2
[DEBUG]   Excluded: org.apache.maven:maven-project:jar:2.0.8
[DEBUG]   Excluded: org.apache.maven:maven-profile:jar:2.0.8
[DEBUG]   Excluded: org.apache.maven:maven-artifact-manager:jar:2.0.8
[DEBUG]   Excluded: org.apache.maven:maven-plugin-registry:jar:2.0.8
[DEBUG] Configuring mojo org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site from plugin realm ClassRealm[plugin>org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT, parent: sun.misc.Launcher$AppClassLoader@7a9664a1]
[DEBUG] Configuring mojo 'org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site' with basic configurator -->
[DEBUG]   (f) artifacts = [org.apache.commons:commons-lang3:3.1, org.scalatest:scalatest_2.9.2:1.8]
[DEBUG]   (f) buildDirectory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target
[DEBUG]   (f) compressSite = true
[DEBUG]   (f) destinationDirectory = /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/target/repository
[DEBUG]   (f) forkedProcessTimeoutInSeconds = 0
[DEBUG]   (f) pedantic = false
[DEBUG]   (f) project = MavenProject: org.reficio.rcp:example-p2-site:1.0.0 @ /Users/krikava/Documents/Projects/sigma/fr.unice.i3s.sigma.targetplatform/pom.xml
[DEBUG]   (f) projectRepos = [reficio (http://repo.reficio.org/maven/, releases+snapshots), sonatype.release (https://oss.sonatype.org/content/repositories/releases/, releases), sonatype.snapshot (https://oss.sonatype.org/content/repositories/snapshots, releases+snapshots), central (http://repo1.maven.org/maven2, releases)]
[DEBUG]   (f) repoSession = org.sonatype.aether.util.DefaultRepositorySystemSession@51f88fbd
[DEBUG]   (f) session = org.apache.maven.execution.MavenSession@7e566633
[DEBUG] -- end configuration --
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.103s
[INFO] Finished at: Wed Aug 01 23:09:00 CEST 2012
[INFO] Final Memory: 5M/81M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) on project example-p2-site: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site (generate-p2-site) on project example-p2-site: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:225)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
     at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
     at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
     at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
     at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
     at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
     at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
     at java.lang.reflect.Method.invoke(Method.java:597)
     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
     at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
     at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution generate-p2-site of goal org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT:site failed: java.lang.NullPointerException
     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:110)
     at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
     ... 19 more
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
     at org.reficio.p2.P2Mojo.execute(P2Mojo.java:199)
     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
     ... 20 more
Caused by: java.lang.NullPointerException
     at org.apache.maven.artifact.DefaultArtifact.<init>(DefaultArtifact.java:116)
     at org.apache.maven.artifact.DefaultArtifact.<init>(DefaultArtifact.java:87)
     at org.reficio.p2.utils.BundleUtils.aetherToMavenArtifactBasic(BundleUtils.java:48)
     at org.reficio.p2.utils.BundleUtils.getBundleVersion(BundleUtils.java:61)
     at org.reficio.p2.utils.BundleWrapper.setBundleOptions(BundleWrapper.java:191)
     at org.reficio.p2.utils.BundleWrapper.initializeAnalyzer(BundleWrapper.java:168)
     at org.reficio.p2.utils.BundleWrapper.handleVanillaJarWrap(BundleWrapper.java:120)
     at org.reficio.p2.utils.BundleWrapper.doWrap(BundleWrapper.java:106)
     at org.reficio.p2.utils.BundleWrapper.wrapArtifacts(BundleWrapper.java:98)
     at org.reficio.p2.utils.BundleWrapper.execute(BundleWrapper.java:63)
     at org.reficio.p2.P2Mojo.executeBndWrapper(P2Mojo.java:218)
     at org.reficio.p2.P2Mojo.execute(P2Mojo.java:192)
     ... 21 more
[ERROR]
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```
