### PR TITLE
prevent IOException: Unable to delete file

### DIFF
--- a/src/main/java/org/reficio/p2/utils/BundleWrapper.java
+++ b/src/main/java/org/reficio/p2/utils/BundleWrapper.java
@@ -30,6 +30,7 @@ import org.sonatype.aether.artifact.Artifact;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.Attributes;
@@ -143,8 +144,11 @@ public class BundleWrapper {
                     continue;
                 }
                 zipOutputStream.putNextEntry(entry);
-                IOUtils.copy(zip.getInputStream(entry), zipOutputStream);
+                InputStream zipInputStream = zip.getInputStream(entry);
+                IOUtils.copy(zipInputStream, zipOutputStream);
+                zipInputStream.close();
             }
+            zip.close();
             zipOutputStream.close();
             FileUtils.copyFile(unsignedJar, jarToUnsign);
             unsignedJar.delete();


### PR DESCRIPTION
I've created a small pom with 2 artifacts. In some cases maven failed and reported that it can not remove the source directory. With some closing statements it runs :)

``` java
java.io.IOException: Unable to delete file /project/target/source/plugins/acb-1.0.0.jar
    at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1919)
    at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1399)
    at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1331)
    at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1910)
    at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1399)
    at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1331)
    at org.reficio.p2.P2Mojo.cleanupEnvironment(P2Mojo.java:280)
    at org.reficio.p2.P2Mojo.execute(P2Mojo.java:203)
```
