### PR TITLE
Migration to tycho 0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <maven.version>3.0.4</maven.version>
-        <tycho.version>0.15.0</tycho.version>
+        <tycho.version>0.16.0</tycho.version>
         <aether.version>1.13.1</aether.version>
         <wagon.version>2.2</wagon.version>
     </properties>

--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -248,7 +248,7 @@ public class P2Mojo extends AbstractMojo {
                 plugin(
                         groupId("org.eclipse.tycho.extras"),
                         artifactId("tycho-p2-extras-plugin"),
-                        version("0.14.0")
+                        version("0.16.0")
                 ),
                 goal("publish-features-and-bundles"),
                 configuration(


### PR DESCRIPTION
This commit will change the tycho (and sisu) version to 0.16.0. This has been needed for me, as the 0.14.0 version of sisu seems to be incompatible with the current version of eclipse. Just changing the version caused the plugin to work for me.
