### PR TITLE
workaround frequent cleanup problems on win7

### DIFF
--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -197,7 +197,8 @@ public class P2Mojo extends AbstractMojo {
             executeBndWrapper();
             executeP2PublisherPlugin();
             executeCategoryPublisher();
-            cleanupEnvironment();
+            final boolean relyOnMvnClean = Boolean.getBoolean("org.reficio.clean.relyOnMaven");
+            if (! relyOnMvnClean) cleanupEnvironment();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
see also https://github.com/reficio/p2-maven-plugin/issues/12

the idea was, that the user can specify
    -Dorg.reficio.clean.relyOnMaven=true
if the user prefers to skip cleanupEnvironment() completely and rather rely on
Maven to cleanup at beginning of next build ...
    mvn clean p2:site

Cheers!

p.s. unfortunately, I could not run tests, because my m2e rejects plugin execution for mycila, gmaven and plexus because they are not covered by default lifecycle configuration
