### PR TITLE
Upgrade to BND 3.0.0 and Tycho 0.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.version>3.2.3</maven.version>
         <maven.annotations.version>3.3</maven.annotations.version>
         <maven.plugin.plugin.version>3.3</maven.plugin.plugin.version>
-        <tycho.version>0.21.0</tycho.version>
+        <tycho.version>0.23.1</tycho.version>
 
         <sonatype.aether.version>1.13.1</sonatype.aether.version>
         <eclipse.aether.version>0.9.0.M3</eclipse.aether.version>
@@ -159,11 +159,11 @@
             <artifactId>guava</artifactId>
             <version>15.0</version>
         </dependency>
-        <dependency>
-            <groupId>biz.aQute</groupId>
-            <artifactId>bnd</artifactId>
-            <version>1.50.0</version>
-        </dependency>
+ 		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bnd</artifactId>
+			<version>3.0.0</version>
+		</dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
-            <version>2.3.6</version>
+            <version>3.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.osgi</groupId>

--- a/src/main/java/org/reficio/p2/P2Helper.java
+++ b/src/main/java/org/reficio/p2/P2Helper.java
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.Jar;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;

--- a/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
+++ b/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2.bundler.impl;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.Jar;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 import org.apache.commons.io.FileUtils;
 import org.reficio.p2.bundler.ArtifactBundler;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;
@@ -91,7 +91,6 @@ public class AquteBundler implements ArtifactBundler {
     private void handleVanillaJarWrap(ArtifactBundlerRequest request, ArtifactBundlerInstructions instructions) throws Exception {
         Analyzer analyzer = AquteHelper.buildAnalyzer(request, instructions, pedantic);
         try {
-            analyzer.calcManifest();
             populateJar(analyzer, request.getBinaryOutputFile());
             bundleUtils.reportErrors(analyzer);
             removeSignature(request.getBinaryOutputFile());
@@ -102,6 +101,7 @@ public class AquteBundler implements ArtifactBundler {
 
     private void populateJar(Analyzer analyzer, File outputFile) throws Exception {
         Jar jar = analyzer.getJar();
+        jar.setManifest(analyzer.calcManifest());
         try {
             jar.write(outputFile);
         } finally {

--- a/src/main/java/org/reficio/p2/bundler/impl/AquteHelper.java
+++ b/src/main/java/org/reficio/p2/bundler/impl/AquteHelper.java
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2.bundler.impl;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.Jar;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 import org.apache.commons.io.FileUtils;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;
 import org.reficio.p2.bundler.ArtifactBundlerRequest;

--- a/src/main/java/org/reficio/p2/publisher/BundlePublisher.java
+++ b/src/main/java/org/reficio/p2/publisher/BundlePublisher.java
@@ -36,7 +36,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
  */
 public class BundlePublisher {
 
-    private static final String TYCHO_VERSION = "0.18.1";
+    private static final String TYCHO_VERSION = "0.23.1";
 
     private final Boolean compressSite;
     private final String additionalArgs;

--- a/src/main/java/org/reficio/p2/utils/BundleUtils.java
+++ b/src/main/java/org/reficio/p2/utils/BundleUtils.java
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2.utils;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.Jar;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 import org.apache.felix.bundleplugin.BundlePlugin;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.reficio.p2.resolver.maven.Artifact;

--- a/src/main/java/org/reficio/p2/utils/JarUtils.java
+++ b/src/main/java/org/reficio/p2/utils/JarUtils.java
@@ -18,10 +18,10 @@
  */
 package org.reficio.p2.utils;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.FileResource;
-import aQute.lib.osgi.Jar;
-import aQute.lib.osgi.Resource;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.FileResource;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.w3c.dom.Document;

--- a/src/test/groovy/org/reficio/p2/utils/TestUtils.groovy
+++ b/src/test/groovy/org/reficio/p2/utils/TestUtils.groovy
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2.utils
 
-import aQute.lib.osgi.Analyzer
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Analyzer
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.bundler.impl.AquteBundler
 
 /**

--- a/src/test/integration/bug 20-it/validate.groovy
+++ b/src/test/integration/bug 20-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/bug-17-it/validate.groovy
+++ b/src/test/integration/bug-17-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/bug-28-tests-classifier-it/validate.groovy
+++ b/src/test/integration/bug-28-tests-classifier-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/bug-45-it/validate.groovy
+++ b/src/test/integration/bug-45-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/bug-6-it/validate.groovy
+++ b/src/test/integration/bug-6-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/bug-6-override-it/validate.groovy
+++ b/src/test/integration/bug-6-override-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/bug-6b-it/validate.groovy
+++ b/src/test/integration/bug-6b-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/feature-bundle-01-it/validate.groovy
+++ b/src/test/integration/feature-bundle-01-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'p2.repo/target/repository/features')

--- a/src/test/integration/feature-bundle-02-it/validate.groovy
+++ b/src/test/integration/feature-bundle-02-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'p2.repo/target/repository/features')

--- a/src/test/integration/main-config-bundle-no-override-it/validate.groovy
+++ b/src/test/integration/main-config-bundle-no-override-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/main-config-bundle-override-it/validate.groovy
+++ b/src/test/integration/main-config-bundle-override-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/main-config-not-bundle-it/validate.groovy
+++ b/src/test/integration/main-config-not-bundle-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/notation-it/validate.groovy
+++ b/src/test/integration/notation-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/override-bundle-it/validate.groovy
+++ b/src/test/integration/override-bundle-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/override-bundle-source-it/validate.groovy
+++ b/src/test/integration/override-bundle-source-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/override-bundle-transitive-it/validate.groovy
+++ b/src/test/integration/override-bundle-transitive-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/simple-it/validate.groovy
+++ b/src/test/integration/simple-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/singleton-it/validate.groovy
+++ b/src/test/integration/singleton-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/integration/source-it/validate.groovy
+++ b/src/test/integration/source-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/transitive-it/validate.groovy
+++ b/src/test/integration/transitive-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 import org.reficio.p2.utils.TestUtils as Util;
 
 // verify target

--- a/src/test/integration/unsign-it/validate.groovy
+++ b/src/test/integration/unsign-it/validate.groovy
@@ -21,7 +21,7 @@
 // $Id$
 //
 
-import aQute.lib.osgi.Jar
+import aQute.bnd.osgi.Jar
 
 // verify target
 File target = new File(basedir, 'target/repository/plugins')

--- a/src/test/java/org/reficio/p2/utils/BundleUtilsTest.java
+++ b/src/test/java/org/reficio/p2/utils/BundleUtilsTest.java
@@ -18,8 +18,8 @@
  */
 package org.reficio.p2.utils;
 
-import aQute.lib.osgi.Analyzer;
-import aQute.lib.osgi.Jar;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
Hi,

Updated the bnd and maven-bundle-plugin to latest version as a solution to:

https://github.com/reficio/p2-maven-plugin/issues/81

which is related to: https://issues.apache.org/jira/browse/FELIX-4005

Aside from the pom and imports, the only actual change has been done to the AquteBundler (the calcManifest() method from the bnd's Analyzer doesn't automatically set it on the Jar instance anymore). Also updated Tycho.

I admit I haven't tested it extensively but it does seem to solve the Java 8 problem in the project I'm currently using it with so I thought I'd share.

Cheers,
Łukasz