### PR TITLE
Added flag to disable reusing of snaphost version

### DIFF
--- a/src/main/java/org/reficio/p2/P2Helper.java
+++ b/src/main/java/org/reficio/p2/P2Helper.java
@@ -181,10 +181,12 @@ public class P2Helper {
     }
 
     private static String calculateSnapshotVersion(ResolvedArtifact resolvedArtifact) {
-        // attempt to take the proper snapshot version from the artifact's version
-        String version = resolvedArtifact.getArtifact().getVersion();
-        if (isProperSnapshotVersion(version)) {
-            return version;
+        if(BundleUtils.INSTANCE.isReuseSnapshotVersionFromArtifact()) {
+            // attempt to take the proper snapshot version from the artifact's version
+            String version = resolvedArtifact.getArtifact().getVersion();
+            if (isProperSnapshotVersion(version)) {
+                return version;
+            }
         }
         // attempt to take the proper snapshot version from the artifact's baseVersion
         String baseVersion = resolvedArtifact.getArtifact().getBaseVersion();

--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -56,6 +56,7 @@ import org.reficio.p2.resolver.maven.ArtifactResolutionResult;
 import org.reficio.p2.resolver.maven.ArtifactResolver;
 import org.reficio.p2.resolver.maven.ResolvedArtifact;
 import org.reficio.p2.resolver.maven.impl.AetherResolver;
+import org.reficio.p2.utils.BundleUtils;
 import org.reficio.p2.utils.JarUtils;
 
 import java.io.File;
@@ -143,6 +144,13 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
      */
     @Parameter(defaultValue = "0", alias = "p2.timeout")
     private int forkedProcessTimeoutInSeconds;
+
+    /**
+     * Specifies whether snapshot artifact timestamps should be reused
+     * This can result in inhomogenous naming of artifacts
+     */
+    @Parameter(defaultValue = "true")
+    private boolean reuseSnapshotVersionFromArtifact;
 
     /**
      * Specifies additional arguments to p2Launcher, for example -consoleLog -debug -verbose
@@ -257,6 +265,7 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
     }
 
     private void processArtifacts() {
+        BundleUtils.INSTANCE.setReuseSnapshotVersionFromArtifact(reuseSnapshotVersionFromArtifact);
         Multimap<P2Artifact, ResolvedArtifact> resolvedArtifacts = resolveArtifacts();
         Set<Artifact> processedArtifacts = processRootArtifacts(resolvedArtifacts);
         processTransitiveArtifacts(resolvedArtifacts, processedArtifacts);

--- a/src/main/java/org/reficio/p2/utils/BundleUtils.java
+++ b/src/main/java/org/reficio/p2/utils/BundleUtils.java
@@ -46,6 +46,8 @@ public class BundleUtils extends BundlePlugin {
     private static final String BUNDLE_VERSION = "Bundle-Version";
     private static final String BUNDLE_NAME = "Bundle-Name";
 
+    private boolean reuseSnapshotVersionFromArtifact = true;
+
     public boolean reportErrors(Analyzer analyzer) {
         return super.reportErrors("", analyzer);
     }
@@ -124,4 +126,11 @@ public class BundleUtils extends BundlePlugin {
         return properties;
     }
 
+    public void setReuseSnapshotVersionFromArtifact(boolean in) {
+        reuseSnapshotVersionFromArtifact = in;
+    }
+
+    public boolean isReuseSnapshotVersionFromArtifact() {
+        return reuseSnapshotVersionFromArtifact;
+    }
 }


### PR DESCRIPTION
Reusing the version string might result in non homogeneous version strings in the target platform
This is a fix for issue #99 
