### PR TITLE
Remove duplicated chapter Eclipse Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,29 +436,6 @@ Example usage:
 The plugin also includes the P2 resolver which means that you can include bundles residing in P2 repositories in the generated site.
 Have a look at the P2 example located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/p2/pom.xml
 
-### Eclipse Features
-You can also add eclipse feature bundles to maven and include them in the generated p2 repository.
-
-* build may fail if the maven artifact is not a valid eclipse feature jar
-* source and transitive must both be false for feature artifacts
-* plugins must be added separately, adding the feature will not add the corresponding plugins
-
-Example usage:
-```xml
-	<configuration>
-		<artifacts>
-			<artifact><id>org.apache.commons:commons-lang3:3.1</id></artifact>
-		</artifacts>
-		<features>
-			<artifact>
-				<id>org.reficio:test.feature:1.0.0</id>
-				<source>false</source>
-				<transitive>false</transitive>
-			</artifact>
-		</features>
-	</configuration>
-```
-
 In order to have a P2 artifact resolved include its definition in the `<p2>` tag (not in the `<artifacts>` tag)
 ```xml
     <p2>


### PR DESCRIPTION
I think it came in during a merge, because it was in the midst of chapter "P2 Resolver".