### PR TITLE
Added Properties format for artifacts BND instructions POM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,16 @@ is an equivalent of the following definition:
     <excludes/>
 </artifact>
 ```     
+If the instruction name cannot be used as a XML tag (for example `-noee`), you can use the properties format:
+```xml
+<instructionsProperties>
+    <property>
+        <name>-noee</name>
+        <value>true</value>
+    </property>
+</instructionsProperties>
+```
+Instructions in properties format take precedence over the ones in map format in case of duplicates, which means that if you defined the same instruction both in properties and map format, the value from properties will be used and the warning will be printed to log.
 
 ### Source option
 This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/source/pom.xml

--- a/src/main/java/org/reficio/p2/P2Artifact.java
+++ b/src/main/java/org/reficio/p2/P2Artifact.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Represents one &lt;artifact&gt; section in the plugin configuration.
@@ -69,6 +70,19 @@ public class P2Artifact {
      */
     private Map<String, String> instructions = new LinkedHashMap<String, String>();
 
+    /**
+     * The BND instructions for the bundle.
+     * These properties complement {@link P2Artifact#instructions} with higher priority on duplicate keys.
+     */
+    private Properties instructionsProperties = new Properties();
+
+    /**
+     * Combined BND instructions for the bundle.
+     */
+    private Map<String, String> combinedInstructions = new LinkedHashMap<String, String>();
+
+    private boolean shouldResetCombinedInstructions = true;
+
     public P2Artifact() {
     }
 
@@ -86,6 +100,8 @@ public class P2Artifact {
 
     public void setInstructions(Map<String, String> instructions) {
         this.instructions = instructions;
+
+        markCombinedInstructionsObsolete();
     }
 
     public boolean shouldIncludeTransitive() {
@@ -124,4 +140,40 @@ public class P2Artifact {
         this.excludes = excludes;
     }
 
+    public Properties getInstructionsProperties() {
+        return instructionsProperties;
+    }
+
+    public void setInstructionsProperties(Properties instructionsProperties) {
+        this.instructionsProperties = instructionsProperties;
+
+        markCombinedInstructionsObsolete();
+    }
+
+    public Map<String, String> getCombinedInstructions() {
+        if (shouldResetCombinedInstructions) {
+            resetCombinedInstructions();
+
+            shouldResetCombinedInstructions = false;
+        }
+
+        return combinedInstructions;
+    }
+
+    private void markCombinedInstructionsObsolete() {
+        shouldResetCombinedInstructions = true;
+    }
+
+    private void resetCombinedInstructions() {
+        combinedInstructions = new LinkedHashMap<String, String>();
+
+        if (instructions != null)
+            combinedInstructions.putAll(instructions);
+
+        if (instructionsProperties != null) {
+            for (String key : instructionsProperties.stringPropertyNames()) {
+                combinedInstructions.put(key, instructionsProperties.getProperty(key));
+            }
+        }
+    }
 }

--- a/src/main/java/org/reficio/p2/P2Helper.java
+++ b/src/main/java/org/reficio/p2/P2Helper.java
@@ -119,7 +119,7 @@ public class P2Helper {
             if (resolvedArtifact.isRoot()) {
                 // Instructions are propagated only to the root dependency
                 // and not to the transitive dependencies.
-                builder.instructions(p2Artifact.getInstructions());
+                builder.instructions(p2Artifact.getCombinedInstructions());
             }
             return builder.build();
         } catch (Exception ex) {
@@ -140,7 +140,7 @@ public class P2Helper {
     private static String calculateFullSymbolicName(P2Artifact p2Artifact, ResolvedArtifact resolvedArtifact) throws IOException {
         String symbolicName = null;
         if (resolvedArtifact.isRoot()) {
-            Object symbolicNameValue = p2Artifact.getInstructions().get(Analyzer.BUNDLE_SYMBOLICNAME);
+            Object symbolicNameValue = p2Artifact.getCombinedInstructions().get(Analyzer.BUNDLE_SYMBOLICNAME);
             symbolicName = symbolicNameValue != null ? symbolicNameValue.toString() : null;
         }
         if (symbolicName == null) {
@@ -170,7 +170,7 @@ public class P2Helper {
         String version = null;
         // in case of root artifact try to take the version from the instructions
         if (resolvedArtifact.isRoot()) {
-            Object versionValue = p2Artifact.getInstructions().get(Analyzer.BUNDLE_VERSION);
+            Object versionValue = p2Artifact.getCombinedInstructions().get(Analyzer.BUNDLE_VERSION);
             version = versionValue != null ? Utils.snapshotToTimestamp(versionValue.toString(), timestamp) : null;
         }
         // if contains snapshot (manually set by the user) -> "SNAPSHOT" will be manually replaced

--- a/src/main/java/org/reficio/p2/P2Validator.java
+++ b/src/main/java/org/reficio/p2/P2Validator.java
@@ -36,9 +36,20 @@ public class P2Validator {
     }
 
     private static void validateGeneralConfig(P2Artifact p2Artifact) {
-        if (p2Artifact.shouldIncludeTransitive() && !p2Artifact.getInstructions().isEmpty()) {
+        if (p2Artifact.shouldIncludeTransitive() && !p2Artifact.getCombinedInstructions().isEmpty()) {
             String message = "BND instructions are NOT applied to the transitive dependencies of ";
             Logger.getLog().warn(String.format("%s %s", message, p2Artifact.getId()));
+        }
+
+        if (p2Artifact.getCombinedInstructions().size() != p2Artifact.getInstructions().size()) {
+            for (String propertyName : p2Artifact.getInstructionsProperties().stringPropertyNames()) {
+                if (!p2Artifact.getInstructions().containsKey(propertyName))
+                    continue;
+
+                String message = String.format("BND instruction <%s> from <instructions> " +
+                        "is overridden in <instructionsProperties>", propertyName);
+                Logger.getLog().warn(message);
+            }
         }
     }
 
@@ -46,7 +57,7 @@ public class P2Validator {
         boolean bundle = BundleUtils.INSTANCE.isBundle(resolvedArtifact.getArtifact().getFile());
         if (resolvedArtifact.isRoot() && bundle) {
             // artifact is a bundle and somebody specified instructions without override
-            if (!p2Artifact.shouldOverrideManifest() && !p2Artifact.getInstructions().isEmpty()) {
+            if (!p2Artifact.shouldOverrideManifest() && !p2Artifact.getCombinedInstructions().isEmpty()) {
                 String message = String.format("p2-maven-plugin misconfiguration" +
                         "\n\n\tJar [%s] is already a bundle. " +
                         "\n\tBND instructions are specified, but the <override> flag is set to false." +

--- a/src/test/integration/instructions-properties-it/invoker.properties
+++ b/src/test/integration/instructions-properties-it/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=p2:site

--- a/src/test/integration/instructions-properties-it/pom.xml
+++ b/src/test/integration/instructions-properties-it/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2007 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Id$ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.reficio</groupId>
+        <artifactId>integration</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../integration.xml</relativePath>
+    </parent>
+
+    <artifactId>config</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <description>
+        Test BND instructions in properties format
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.reficio</groupId>
+                <artifactId>p2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <id>org.mockito:mockito-core:1.8.5</id>
+                                    <transitive>false</transitive>
+                                    <override>true</override>
+                                </artifact>
+                                <artifact>
+                                    <id>org.mockito:mockito-core:1.9.0</id>
+                                    <transitive>false</transitive>
+                                    <override>true</override>
+                                    <instructionsProperties>
+                                        <property>
+                                            <name>-noee</name>
+                                            <value>true</value>
+                                        </property>
+                                    </instructionsProperties>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/test/integration/instructions-properties-it/validate.groovy
+++ b/src/test/integration/instructions-properties-it/validate.groovy
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// $Id$
+//
+
+import aQute.bnd.osgi.Jar
+import org.reficio.p2.utils.TestUtils as Util
+
+File target = new File(basedir, 'target/repository/plugins')
+Jar jarWithEE = new Jar(new File(target, "org.mockito.mockito-core_1.8.5.jar"))
+Jar jarWithoutEE = new Jar(new File(target, "org.mockito.mockito-core_1.9.0.jar"))
+
+assert Util.attr(jarWithEE, "Require-Capability").contains("osgi.ee")
+assert Util.attr(jarWithoutEE, "Require-Capability") == null

--- a/src/test/java/org/reficio/p2/P2ArtifactTest.java
+++ b/src/test/java/org/reficio/p2/P2ArtifactTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.p2;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+/**
+ * @since 1.4.0
+ */
+public class P2ArtifactTest {
+
+    @Test
+    public void testCombinedInstructions() {
+        // GIVEN
+        P2Artifact artifact = new P2Artifact();
+        artifact.setInstructions(Collections.singletonMap("Import-Package", "package.one"));
+        Properties instructionsProperties = new Properties();
+        instructionsProperties.setProperty("Export-Package", "package.two");
+        artifact.setInstructionsProperties(instructionsProperties);
+
+        // WHEN
+        Map<String, String> combinedInstructions = artifact.getCombinedInstructions();
+
+        // THEN
+        assertEquals(2, combinedInstructions.size());
+        assertEquals("package.one", combinedInstructions.get("Import-Package"));
+        assertEquals("package.two", combinedInstructions.get("Export-Package"));
+    }
+
+    @Test
+    public void testInstructionsPropertiesOverrideInstructions() {
+        // GIVEN
+        P2Artifact artifact = new P2Artifact();
+        artifact.setInstructions(Collections.singletonMap("Export-Package", "package.one"));
+        Properties instructionsProperties = new Properties();
+        instructionsProperties.setProperty("Export-Package", "package.two");
+        artifact.setInstructionsProperties(instructionsProperties);
+
+        // WHEN
+        Map<String, String> combinedInstructions = artifact.getCombinedInstructions();
+
+        // THEN
+        assertEquals(1, combinedInstructions.size());
+        assertEquals("package.two", combinedInstructions.get("Export-Package"));
+    }
+
+    @Test
+    public void testInstructionsPropertiesOverrideInstructionsWhenPropertiesSetFirst() {
+        // GIVEN
+        P2Artifact artifact = new P2Artifact();
+        Properties instructionsProperties = new Properties();
+        instructionsProperties.setProperty("Export-Package", "package.two");
+        artifact.setInstructionsProperties(instructionsProperties);
+        artifact.setInstructions(Collections.singletonMap("Export-Package", "package.one"));
+
+        // WHEN
+        Map<String, String> combinedInstructions = artifact.getCombinedInstructions();
+
+        // THEN
+        assertEquals(1, combinedInstructions.size());
+        assertEquals("package.two", combinedInstructions.get("Export-Package"));
+    }
+}


### PR DESCRIPTION
I recently came across the problem that there is no way to pass instructions starting with dash to the underlying BND tool. This limitation comes from `<instructions>` property in plugin configuration being mapped to `Map<String, String>` which leads to instruction names being mapped as XML element names, which, in turn, cannot start with dash.
To enable desired configuration option (which some other users miss too, e.g. #136) and not to break existing configurations i decided to add the `<instructionsProperties>` field of type `Properties`, which allows to overcome previously stated limitation.
My solution may be not ideal, for example, it allows users to have duplicate configuration options in `<instructions>` and `<instructionProperties>`, but it fits for my use case.
I will greatly appreciate any feedback.
Sample use case:
```
<artifact>
  <id>...</id>
  <instructions>
    <Bundle-SymbolicName>...</Bundle-SymbolicName>
  </instructions>
  <instructionsProperties>
    <property>
      <name>-noee</name>
      <value>true</value>
    </property>
  </instructionsProperties>
</artifact>
```