### PR TITLE
Replace oraclejdk8 by openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
+  - openjdk13
 install: /bin/true
 script: mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 jdk:
   - openjdk8
-  - openjdk11
-  - openjdk13
 install: /bin/true
 script: mvn clean package


### PR DESCRIPTION
The most project will use openjdk because of license issues. 