### PR TITLE
Housekeeping: Add compatibility to openjdk 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 install: /bin/true
 script: mvn clean package

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
         <eclipse.aether.version>1.1.0</eclipse.aether.version>
 
         <wagon.version>2.2</wagon.version>
-        <gmaven.version>1.5</gmaven.version>
+        <gmaven.version>2.1.1</gmaven.version>
         <gmaven.provider.selection>2.0</gmaven.provider.selection>
-        <groovy.version>2.4.8</groovy.version>
+        <groovy.version>2.5.8</groovy.version>
 
         <clover.version>3.3.0</clover.version>
         <clover.license>/private/reficio/clover.license</clover.license>
@@ -205,23 +205,27 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.10</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-2.0</artifactId>
-            <version>${gmaven.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.codehaus.gmaven.runtime</groupId>-->
+<!--            <artifactId>gmaven-runtime-2.0</artifactId>-->
+<!--            <version>${gmaven.version}</version>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.codehaus.groovy</groupId>-->
+<!--                    <artifactId>groovy-all</artifactId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.codehaus.groovy</groupId>-->
+<!--                    <artifactId>groovy</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
         </dependency>
         <dependency>
@@ -255,12 +259,12 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>${gmaven.version}</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.8.0</version>
                 <configuration>
-                    <source/>
-                    <providerSelection>${gmaven.provider.selection}</providerSelection>
+<!--                    <source/>-->
+<!--                    <providerSelection>${gmaven.provider.selection}</providerSelection>-->
                     <sourceEncoding>UTF-8</sourceEncoding>
                 </configuration>
                 <executions>
@@ -269,14 +273,14 @@
                             <goal>generateStubs</goal>
                             <goal>compile</goal>
                             <goal>generateTestStubs</goal>
-                            <goal>testCompile</goal>
+                            <goal>compileTests</goal>
                         </goals>
                     </execution>
                 </executions>
                 <dependencies>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
+                        <artifactId>groovy</artifactId>
                         <version>${groovy.version}</version>
                     </dependency>
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -208,21 +208,6 @@
             <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.codehaus.gmaven.runtime</groupId>-->
-<!--            <artifactId>gmaven-runtime-2.0</artifactId>-->
-<!--            <version>${gmaven.version}</version>-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>org.codehaus.groovy</groupId>-->
-<!--                    <artifactId>groovy-all</artifactId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <groupId>org.codehaus.groovy</groupId>-->
-<!--                    <artifactId>groovy</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
@@ -659,7 +644,7 @@
                         <dependencies>
                             <dependency>
                                 <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
+                                <artifactId>groovy</artifactId>
                                 <version>${groovy.version}</version>
                             </dependency>
                         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -391,6 +391,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <source>1.6</source>
                     <quiet>true</quiet>
                     <links>
                         <link>http://docs.oracle.com/javase/6/docs/api/</link>

--- a/src/main/java/org/reficio/p2/utils/JarUtils.java
+++ b/src/main/java/org/reficio/p2/utils/JarUtils.java
@@ -70,6 +70,13 @@ public class JarUtils {
     
     /**
      * Opens the feature.xml in the given jar file and adjusts all version numbers/timestamps
+     *
+     * @param inputFile - inputFile
+     * @param outputFile - outputFile
+     * @param log - log
+     * @param pluginDir - pluginDir
+     * @param timestamp - timestamp
+     *
      */
     public static void adjustFeatureXml(File inputFile, File outputFile, File pluginDir, Log log, String timestamp) {
         Jar jar = null;
@@ -117,6 +124,12 @@ public class JarUtils {
     
 	/**
 	 * Adjust the pluginId TODO - this may be wrong if singleton is used
+     *
+     * @param pluginDir - pluginDir
+     * @param featureSpec - featureSpec
+     * @param log  - log
+     *
+     * @throws IOException - an exception
 	 */
     public static void adjustFeaturePluginData(Document featureSpec, File pluginDir, Log log) throws IOException {
 	        //get list of all plugins


### PR DESCRIPTION
- update Groovy version fix #139 
- replace by gmaven-plugin by gmavenplus-maven-plugin (newer version of gmaven supports only running groovy script during a build, but no anymore build tool tasks)
- update javadoc-maven-plugin version
- adjust javadoc config 
- update mockito version