### PR TITLE
adjust version to 1.3.0 (#147)

### DIFF
--- a/examples/excludes/pom.xml
+++ b/examples/excludes/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/examples/override/pom.xml
+++ b/examples/override/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/examples/p2/pom.xml
+++ b/examples/p2/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/examples/phase/pom.xml
+++ b/examples/phase/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <!-- PHASE EXAMPLE -->

--- a/examples/source/pom.xml
+++ b/examples/source/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/examples/transitive/pom.xml
+++ b/examples/transitive/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>


### PR DESCRIPTION
fix #147 

adjust version to 1.3.0, so that examples could run without reflcio repository