### PR TITLE
Remove duplicate blank from log output

### DIFF
--- a/src/main/java/org/reficio/p2/P2Validator.java
+++ b/src/main/java/org/reficio/p2/P2Validator.java
@@ -37,8 +37,9 @@ public class P2Validator {
 
     private static void validateGeneralConfig(P2Artifact p2Artifact) {
         if (p2Artifact.shouldIncludeTransitive() && !p2Artifact.getCombinedInstructions().isEmpty()) {
-            String message = "BND instructions are NOT applied to the transitive dependencies of ";
-            Logger.getLog().warn(String.format("%s %s", message, p2Artifact.getId()));
+            String message = String.format("BND instructions are NOT applied to the transitive dependencies of %s",
+                    p2Artifact.getId());
+            Logger.getLog().warn(message);
         }
 
         if (p2Artifact.getCombinedInstructions().size() != p2Artifact.getInstructions().size()) {


### PR DESCRIPTION
The printed warning message contained a duplicate blank due to the fixed message part ending with one, and using another one in the String format pattern.