### PR TITLE
Fix src/test/integration/feature-14-it

### DIFF
--- a/src/test/integration/feature-14-it/pom.xml
+++ b/src/test/integration/feature-14-it/pom.xml
@@ -59,13 +59,6 @@
                                     <transitive>false</transitive>
                                 </artifact>
 
-                                <!-- snapshot to snapshot conversion plugin -->
-                                <artifact>
-                                    <id>org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT</id>
-                                    <source>true</source>
-                                    <transitive>false</transitive>
-                                </artifact>
-
                                 <!-- snapshot to non-snapshot conversion with override -->
                                 <artifact>
                                     <id>org.hibernate:hibernate-c3p0:4.3.0-SNAPSHOT</id>
@@ -133,21 +126,10 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>plugin-reficio</id>
-            <url>http://repo.reficio.org/maven</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <repositories>
         <repository>
             <id>hibernate-snapshots</id>
             <url>http://snapshots.jboss.org/maven2</url>
-        </repository>
-        <repository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven</url>
         </repository>
     </repositories>
 

--- a/src/test/integration/feature-14-it/validate.groovy
+++ b/src/test/integration/feature-14-it/validate.groovy
@@ -24,16 +24,11 @@ import static org.reficio.p2.utils.TestUtils.*;
 
 File target = new File(basedir, 'target/repository/plugins')
 assert target.exists()
-assert target.listFiles().size() == 14
+assert target.listFiles().size() == 12
 
 // <!-- snapshot to snapshot conversion jar -->
 validateOriginalSnapshot(jar(target, "org.hibernate.core_4.3.0."), "4.3.0.")
 validateOriginalSnapshot(jar(target, "org.hibernate.core.source_4.3.0."), "4.3.0.")
-
-// sometimes it's original, sometimes it's repacked - depending on Maven Packaging...???
-// <!-- snapshot to snapshot conversion plugin -->
-// validateOriginalSnapshot(jar(target, "org.reficio.p2-maven-plugin_1.0.0."), "1.0.0.")
-// validateOriginalSnapshot(jar(target, "org.reficio.p2-maven-plugin.source_1.0.0."), "1.0.0.")
 
 // <!-- snapshot to non-snapshot conversion with override -->
 validateVersion(jar(target, "com.hibernato.poolo_1.2.3"), "1.2.3")


### PR DESCRIPTION
Remove the dependency on org.reficio:p2-maven-plugin:1.0.0-SNAPSHOT
in the test case.

That old SNAPSHOT version was only found in the
  http://repo.reficio.org/maven
repository. That repo does not exist anymore, so the artifact
cannot be used as a test object anymore.

In face, the assertion on that bundle was removed a while ago in
  validate.groovy
anyways, so it can safely be removed fully.