### PR TITLE
Remove references to obsolete http://repo.reficio.org/maven/ repo

### DIFF
--- a/examples/excludes/pom.xml
+++ b/examples/excludes/pom.xml
@@ -75,13 +75,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/examples/override/pom.xml
+++ b/examples/override/pom.xml
@@ -75,13 +75,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/examples/phase/pom.xml
+++ b/examples/phase/pom.xml
@@ -48,13 +48,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -103,13 +103,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/examples/source/pom.xml
+++ b/examples/source/pom.xml
@@ -54,13 +54,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/examples/transitive/pom.xml
+++ b/examples/transitive/pom.xml
@@ -50,13 +50,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -683,14 +683,6 @@
         </profile>
     </profiles>
 
-    <repositories>
-        <!-- required to get the reficio-skin -->
-        <repository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <repository>
             <id>reficio</id>

--- a/src/test/integration/bug-18-it/pom.xml
+++ b/src/test/integration/bug-18-it/pom.xml
@@ -225,11 +225,4 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/src/test/integration/bug-19-it/pom.xml
+++ b/src/test/integration/bug-19-it/pom.xml
@@ -120,11 +120,4 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/src/test/integration/bug-28-tests-classifier-it/pom.xml
+++ b/src/test/integration/bug-28-tests-classifier-it/pom.xml
@@ -50,11 +50,4 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/src/test/integration/bug-39-parse-error-it/pom.xml
+++ b/src/test/integration/bug-39-parse-error-it/pom.xml
@@ -136,11 +136,4 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>


### PR DESCRIPTION
The repository http://repo.reficio.org/maven/ does not exist anymore.
It is also obsolete since p2-maven-plugin is published on maven central.