### PR TITLE
fix project home url in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>maven-plugin</packaging>
     <version>1.5.1-SNAPSHOT</version>
     <name>p2-maven-plugin</name>
-    <url>http://projects.reficio.org/${project.artifactId}/${project.version}</url>
+    <url>https://github.com/reficio/p2-maven-plugin</url>
     <description>Maven plugin for the automation of jars wrapping and p2 site generation</description>
 
     <properties>


### PR DESCRIPTION
Maven search points to a non-reachable homepage for this project. Let's
change it to github therefore.