### PR TITLE
#176: Update BND Tool to 5.x

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Reficio (TM) - Reestablish your software! All Rights Reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 1
+update_configs:
+  - package_manager: "java:maven"
+    directory: "."
+    update_schedule: "monthly"

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.7</java.version>
+        <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -430,7 +430,7 @@
                     <source>${java.version}</source>
                     <quiet>true</quiet>
                     <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
+                        <link>http://docs.oracle.com/javase/11/docs/api/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.annotations.version>3.6.0</maven.annotations.version>
         <maven.plugin.plugin.version>3.6.0</maven.plugin.plugin.version>
         <!-- actually a dependency here. -->
-        <dependency.maven.bundle.plugin.version>3.2.0</dependency.maven.bundle.plugin.version>
+        <dependency.maven.bundle.plugin.version>4.2.1</dependency.maven.bundle.plugin.version>
         <tycho.version>1.0.0</tycho.version>
 
         <sonatype.aether.version>1.13.1</sonatype.aether.version>
@@ -193,8 +193,8 @@
             <version>${dependency.maven.bundle.plugin.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.core</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -326,7 +326,7 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>1.5.5</version>
+                <version>2.1.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <maven.version>3.3.9</maven.version>
-        <maven.annotations.version>3.5</maven.annotations.version>
-        <maven.plugin.plugin.version>3.3</maven.plugin.plugin.version>
+        <maven.version>3.6.3</maven.version>
+        <maven.annotations.version>3.6.0</maven.annotations.version>
+        <maven.plugin.plugin.version>3.6.0</maven.plugin.plugin.version>
         <!-- actually a dependency here. -->
         <dependency.maven.bundle.plugin.version>3.2.0</dependency.maven.bundle.plugin.version>
         <tycho.version>1.0.0</tycho.version>
@@ -110,7 +110,6 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- dependencies to annotations -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,7 @@
                         <exclude>target/**</exclude>
                         <exclude>**/resources/**</exclude>
                         <exclude>.clover/**</exclude>
+                        <exclude>.dependabot/**</exclude>
                     </excludes>
                     <useDefaultExcludes>true</useDefaultExcludes>
                     <mapping>

--- a/src/main/java/org/reficio/p2/utils/JarUtils.java
+++ b/src/main/java/org/reficio/p2/utils/JarUtils.java
@@ -23,7 +23,6 @@ import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
-import edu.emory.mathcs.backport.java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.logging.Log;
@@ -33,6 +32,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.jar.Attributes;

--- a/src/test/integration/bug-39-parse-error-it/validate.groovy
+++ b/src/test/integration/bug-39-parse-error-it/validate.groovy
@@ -1,3 +1,7 @@
+import org.codehaus.plexus.util.Os
+
+import static org.codehaus.plexus.util.Os.FAMILY_WINDOWS
+
 /**
  * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
  *
@@ -23,4 +27,12 @@
 
 File target = new File(basedir, 'target/repository/plugins')
 assert target.exists()
-assert target.listFiles().size() == 34
+
+if (Os.isFamily(FAMILY_WINDOWS)) {
+    // on windows the file org.eclipse.swt.gtk.linux.x86_64_3.3.0.v3346.jar doesn't exist
+    assert target.listFiles().size() == 33
+} else {
+    assert target.listFiles().size() == 34
+}
+
+


### PR DESCRIPTION
Preparation step for updating Tycho and BND.

- updating Maven 3.6.3 (is required by Tycho 2.x)