### PR TITLE
[#194] dependency cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <maven.version>3.3.9</maven.version>
-        <maven.annotations.version>3.5</maven.annotations.version>
+        <maven.annotations.version>3.3</maven.annotations.version>
         <maven.plugin.plugin.version>3.3</maven.plugin.plugin.version>
         <!-- actually a dependency here. -->
         <dependency.maven.bundle.plugin.version>4.2.1</dependency.maven.bundle.plugin.version>
@@ -84,6 +84,53 @@
                 <artifactId>biz.aQute.bndlib</artifactId>
                 <version>5.2.0</version>
             </dependency>
+
+            <!-- 3.0 used by tycho. Force the target maven version here. -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <!-- 3.0 used by tycho. Force the target maven version here. -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <!-- 3.0 used by tycho. Force the target maven version here. -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <!-- 3.0 used by org.twdata.maven:mojo-executor. -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <!-- 3.0 used by tycho -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <!-- 3.0 used by maven-plugin-annotations -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+
+            <!-- 1.5.5 used by tycho, others use 1.6 -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-annotations</artifactId>
+                <version>1.6</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -92,26 +139,12 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
+
         <!-- dependencies to annotations -->
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -121,6 +154,10 @@
             <!-- annotations are needed only to build the plugin -->
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-component-annotations</artifactId>
+        </dependency>
 
         <!-- org.sonatype.aether artifacts ARE provided by Maven 3.0.x -->
         <dependency>
@@ -149,24 +186,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
             <version>2.6</version>
         </dependency>
         <dependency>
@@ -177,11 +198,6 @@
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bndlib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>
@@ -199,17 +215,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-core</artifactId>
             <version>${tycho.version}</version>
         </dependency>
         <dependency>
-        	<groupId>org.eclipse.tycho</groupId>
-        	<artifactId>tycho-packaging-plugin</artifactId>
-        	<version>${tycho.version}</version>
-        	<type>maven-plugin</type>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>sisu-equinox-launching</artifactId>
+            <version>${tycho.version}</version>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -226,11 +243,6 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.cenqua.clover</groupId>
-            <artifactId>clover</artifactId>
-            <version>${clover.version}</version>
         </dependency>
     </dependencies>
 
@@ -676,6 +688,31 @@
                                 <goals>
                                     <goal>install</goal>
                                     <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>convergence</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <executions>
+                            <execution>
+                                <id>enforce</id>
+                                <configuration>
+                                    <rules>
+                                        <dependencyConvergence/>
+                                    </rules>
+                                </configuration>
+                                <goals>
+                                    <goal>enforce</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/main/groovy/org/reficio/p2/resolver/maven/impl/AetherResolver.groovy
+++ b/src/main/groovy/org/reficio/p2/resolver/maven/impl/AetherResolver.groovy
@@ -18,7 +18,6 @@
  */
 package org.reficio.p2.resolver.maven.impl
 
-import org.apache.commons.lang.StringUtils
 import org.reficio.p2.logger.Logger
 import org.reficio.p2.resolver.maven.impl.facade.AetherFacade
 import org.reficio.p2.resolver.maven.Artifact
@@ -128,7 +127,7 @@ class AetherResolver implements ArtifactResolver {
     private static List<String> transformExcludes(String artifact, List<String> excludes) {
         List<String> transformedExcludes = []
         for (String exclude : excludes) {
-            if (StringUtils.isBlank(exclude)) {
+            if (exclude == null || exclude.trim().isEmpty()) {
                 // aether bug fix
                 Logger.getLog().warn("Empty exclude counts as exclude-all wildcard '*' [${artifact}]")
                 transformedExcludes += "*"

--- a/src/main/java/org/reficio/p2/FeatureBuilder.java
+++ b/src/main/java/org/reficio/p2/FeatureBuilder.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang.StringUtils;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;
 import org.reficio.p2.logger.Logger;
 import org.reficio.p2.utils.JarUtils;
@@ -178,7 +177,7 @@ public class FeatureBuilder {
 				if (generateSourceFeature) {
 					// 2015-05-12/RPr: A Source feature contains only sources.
 					id = abi.getSourceSymbolicName();
-					if (StringUtils.isBlank(id)) {
+					if (id == null || id.trim().isEmpty()) {
 						log().info("\t [WARN] No source found for " + abi.getSymbolicName());
 						continue;
 					}

--- a/src/main/java/org/reficio/p2/P2Helper.java
+++ b/src/main/java/org/reficio/p2/P2Helper.java
@@ -21,14 +21,12 @@ package org.reficio.p2;
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Jar;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;
 import org.reficio.p2.bundler.ArtifactBundlerRequest;
 import org.reficio.p2.bundler.impl.AquteHelper;
 import org.reficio.p2.resolver.maven.Artifact;
 import org.reficio.p2.resolver.maven.ResolvedArtifact;
 import org.reficio.p2.utils.BundleUtils;
-import org.reficio.p2.utils.JarUtils;
 import org.reficio.p2.utils.Utils;
 
 import java.io.File;
@@ -151,7 +149,7 @@ public class P2Helper {
         }
         // bug28 - handle classifiers
         String classifier = resolvedArtifact.getArtifact().getClassifier();
-        if (StringUtils.isNotBlank(classifier)) {
+        if (classifier != null && !classifier.trim().equals("")) {
             symbolicName += "." + classifier;
         }
         return symbolicName;

--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.AbstractMojoExecutionException;
@@ -542,7 +541,7 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
     }
 
     private void prepareCategoryLocationFile() throws IOException {
-        if (StringUtils.isBlank(categoryFileURL)) {
+        if (categoryFileURL == null || categoryFileURL.trim().isEmpty()) {
             InputStream is = getClass().getResourceAsStream(DEFAULT_CATEGORY_CLASSPATH_LOCATION + DEFAULT_CATEGORY_FILE);
             File destinationFolder = new File(destinationDirectory);
             destinationFolder.mkdirs();

--- a/src/main/java/org/reficio/p2/resolver/maven/Artifact.java
+++ b/src/main/java/org/reficio/p2/resolver/maven/Artifact.java
@@ -19,8 +19,7 @@
 package org.reficio.p2.resolver.maven;
 
 import java.io.File;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.Objects;
 
 import static java.util.Arrays.asList;
 
@@ -116,11 +115,14 @@ public class Artifact {
 
     @Override
     public boolean equals(Object other) {
-        return EqualsBuilder.reflectionEquals(this, other, asList("file"));
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        Artifact artifact = (Artifact) other;
+        return snapshot == artifact.snapshot && Objects.equals(groupId, artifact.groupId) && Objects.equals(artifactId, artifact.artifactId) && Objects.equals(baseVersion, artifact.baseVersion) && Objects.equals(extension, artifact.extension) && Objects.equals(classifier, artifact.classifier) && Objects.equals(version, artifact.version) && Objects.equals(file, artifact.file);
     }
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, asList("file"));
+        return Objects.hash(groupId, artifactId, baseVersion, extension, classifier, snapshot, version, file);
     }
 }

--- a/src/test/integration/integration.xml
+++ b/src/test/integration/integration.xml
@@ -54,9 +54,6 @@
                     <groupId>org.reficio</groupId>
                     <artifactId>p2-maven-plugin</artifactId>
                     <version>@project.version@</version>
-                    <configuration>
-                        <providerSelection>1.5</providerSelection>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -67,9 +64,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <source>1.4</source>
+                    <source>1.7</source>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- use less transitive dependencies (tycho-plugins -> tycho-core + sisu-equinox-launching)
- update commons-io to 2.6
- define versions for explicitly and transitively used dependencies
- remove unused dependencies (commons collections)
- remove rarely used dependencies like commons-lang (can easily be replaced).
  - aside from this: using reflection for equals and hashcode is not a good idea.
- added a convergence profile, we will need this again when upgrading tycho.