### PR TITLE
[#226] replace findbugs with spotbugs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,9 +56,33 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: License Check
-        run: mvn apache-rat:check "-Drat.consoleOutput"
+        run: mvn --batch-mode apache-rat:check "-Drat.consoleOutput"
 
 
       - name: Build with Maven
-        run: mvn --batch-mode --errors package --file pom.xml '-Dinvoker.streamLogs=true'
+        run: mvn --batch-mode --errors verify --file pom.xml '-Dinvoker.streamLogs=true' '-Pit'
 
+  verify:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up cache for ~./m2/repository
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ matrix.os }}-java${{ matrix.java }}-
+            maven-${{ matrix.os }}-
+
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Spotbugs check
+        run: mvn --batch-mode --errors verify --file pom.xml '-Pspotbugs'

--- a/README.md
+++ b/README.md
@@ -621,10 +621,19 @@ Please describe the issue thoroughly. Please include a minimal pom.xml file that
 If you submit a pull request please make sure to add an unit/integration test case that covers the feature. Pull requests without a proper test coverage may not be pulled at all.
 
 ### Running integration tests
+
 Invoke the following command to run the integration tests suite:
 
 ```
-$ mvn package
+$ mvn verify -Pit
+```
+
+### Running the spotbugs checks
+
+Invoke the following command to run the spotbugs checks:
+
+```
+$ mvn verify -Pspotbugs
 ```
 
 ### Releasing

--- a/pom.xml
+++ b/pom.xml
@@ -625,22 +625,22 @@
         </profile>
 
         <profile>
-            <id>findbugs</id>
+            <id>spotbugs</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>2.4.0</version>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>4.2.0</version>
                         <executions>
                             <execution>
-                                <id>findbugs</id>
-                                <phase>process-classes</phase>
+                                <id>default-spotbugs</id>
+                                <phase>verify</phase>
                                 <goals>
-                                    <goal>findbugs</goal>
+                                    <goal>check</goal>
                                 </goals>
                                 <configuration>
-                                    <xmlOutput>true</xmlOutput>
+                                    <maxHeap>2048</maxHeap>
                                     <excludeFilterFile>src/main/resources/findbugs-exclude.xml</excludeFilterFile>
                                 </configuration>
                             </execution>
@@ -652,9 +652,6 @@
 
         <profile>
             <id>it</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -689,7 +686,7 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <phase>package</phase>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>install</goal>
                                     <goal>run</goal>


### PR DESCRIPTION
*  redefine profiles
* update CI
  * verify phase for ITs and spotbugs, as they are the default phases for both plugins. Do not deviate from sane defaults if not needed (convention over configuration)
* update README.md to reflect the updated contribution guidelines (run verify with both profiles)



fixes #226 

Checks from GH Actions are expected to fail due to spotbugs issues.