### PR TITLE
#241:Embebbed BND Tool ends with errors but build is sucessfull

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ What will be the behavior like if we use the configuration listed below?
 * transitive dependencies will be fetched
 * jars containing source code will NOT be fetched
 * jars that are **NOT** osgi bundles will be "bundled" using bnd tool; if instructions are specified, they will be APPLIED.
+* errors throwing by bnd tool are ignored 
 * jars that are osgi bundles will be simply included, if instructions are specified, they will be **IGNORED** (see override example)
 * p2 site will be generated
 
@@ -317,6 +318,12 @@ Example usage:
     <transitive>false</transitive>
 </artifact>
 ```
+
+### Skip BND tool errors option
+This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/bnd-errors/pom.xml
+
+Because of backward compatibility, BND tool error are ignoring by default.
+You can break the P2 build when BND tool produces errors with the flag `<skipBndErrors>false</skipBndErrors>` in the `<configuration>` section.  
 
 ### Maven phase binding
 This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/phase/pom.xml

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Example usage:
 This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/bnd-errors/pom.xml
 
 Because of backward compatibility, BND tool error are ignoring by default.
-You can break the P2 build when BND tool produces errors with the flag `<skipBndErrors>false</skipBndErrors>` in the `<configuration>` section.  
+You can break the P2 build when BND tool produces errors with the flag `<ignoreBndErrors>false</ignoreBndErrors>` in the `<configuration>` section.  
 
 ### Maven phase binding
 This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/phase/pom.xml

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ What will be the behavior like if we use the configuration listed below?
 * transitive dependencies will be fetched
 * jars containing source code will NOT be fetched
 * jars that are **NOT** osgi bundles will be "bundled" using bnd tool; if instructions are specified, they will be APPLIED.
-* errors throwing by bnd tool are ignored 
+* errors thrown by bnd tool are ignored 
 * jars that are osgi bundles will be simply included, if instructions are specified, they will be **IGNORED** (see override example)
 * p2 site will be generated
 
@@ -322,7 +322,7 @@ Example usage:
 ### Skip BND tool errors option
 This example is located here: https://github.com/reficio/p2-maven-plugin/blob/master/examples/bnd-errors/pom.xml
 
-Because of backward compatibility, BND tool error are ignoring by default.
+Because of backward compatibility, BND tool errors are ignored by default.
 You can break the P2 build when BND tool produces errors with the flag `<ignoreBndErrors>false</ignoreBndErrors>` in the `<configuration>` section.  
 
 ### Maven phase binding

--- a/examples/bnd-errors/pom.xml
+++ b/examples/bnd-errors/pom.xml
@@ -43,7 +43,7 @@
                         <!--
                         This is the configuration when bnd tools errors should break the p2 build.
 
-                        The flag skipBndErrors has to be set to false.
+                        The flag ignoreBndErrors has to be set to false.
 
                         The default behaviour of the p2-maven-plugin is to ignore bnd errors,
                         because of backward compatibility reasons (elder versions of p2-maven-plugin ignore them)
@@ -51,7 +51,7 @@
                         To run the example please invoke: mvn p2:site
                         -->
                         <configuration>
-                            <skipBndErrors>false</skipBndErrors>
+                            <ignoreBndErrors>false</ignoreBndErrors>
                             <artifacts>
                                 <artifact>
                                     <id>commons-lang:commons-lang:2.4</id>

--- a/examples/bnd-errors/pom.xml
+++ b/examples/bnd-errors/pom.xml
@@ -39,58 +39,19 @@
                 <executions>
                     <execution>
                         <id>default-cli</id>
-                        <!-- QUICK-START EXAMPLE -->
+                        <!-- BND-ERRORS EXAMPLE -->
                         <!--
-                        This is the default quick-start configuration.
+                        This is the configuration when bnd tools errors should break the p2 build.
 
-                        Expected behavior:
-                          - specified dependencies will be fetched
-                          - transitive dependencies will be fetched (no default exclusions)
-                          - jars containing source source code will NOT be fetched
-                          - jars that are NOT OSGi bundles will be "bundled" using bnd tool,
-                            if you specify instructions for these jars they will be APPLIED
-                          - errors throwing by bnd tool are ignored
-                          - jars that are OSGi bundles will be simply included
-                            if you specify instructions for these jars they will be IGNORED (see <override> option)
-                          - p2 site will be generated
+                        The flag skipBndErrors has to be set to false.
 
-                        How the instructions works:
-                          - instructions are applied only to the root artifact that you specify!
-                          - instructions are not applied to the TRANSITIVE dependencies!
-                          - transitive dependencies are never overridden (see <override> option)
-                          - transitive dependencies are bundled using the default instructions:
-                              <instructions>
-                                  <Import-Package>*;resolution:=optional</Import-Package>
-                                  <Export-Package>*</Export-Package>
-                              </instructions>
-                          - other instructions, such as, Bundle-SymbolicName, Bundle-Name, Bundle-Version, etc.
-                            are calculated according to the following rules:
-                            http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html
-                          - if you specify any instructions they will be applied only if
-                            the jar is not already an OSGi bundle - otherwise you have to use the override
-                            option - please see the /examples/override/pom.xml example
-
-                        The following definition of an artifact:
-                            <artifact>
-                                <id>commons-io:commons-io:2.1</id>
-                            </artifact>
-
-                        is an equivalent of the following definition:
-                            <artifact>
-                                <id>commons-io:commons-io:2.1</id>
-                                <transitive>true</transitive>
-                                <source>false</source>
-                                <override>false</override>
-                                <instructions>
-                                    <Import-Package>*;resolution:=optional</Import-Package>
-                                    <Export-Package>*</Export-Package>
-                                </instructions>
-                                <excludes/>
-                            </artifact>
+                        The default behaviour of the p2-maven-plugin is to ignore bnd errors,
+                        because of backward compatibility reasons (elder versions of p2-maven-plugin ignore them)
 
                         To run the example please invoke: mvn p2:site
                         -->
                         <configuration>
+                            <skipBndErrors>false</skipBndErrors>
                             <artifacts>
                                 <artifact>
                                     <id>commons-lang:commons-lang:2.4</id>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -49,7 +49,7 @@
                           - jars containing source source code will NOT be fetched
                           - jars that are NOT OSGi bundles will be "bundled" using bnd tool,
                             if you specify instructions for these jars they will be APPLIED
-                          - errors throwing by bnd tool are ignored
+                          - errors thrown by bnd tool are ignored
                           - jars that are OSGi bundles will be simply included
                             if you specify instructions for these jars they will be IGNORED (see <override> option)
                           - p2 site will be generated

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,6 @@
             <scope>provided</scope>
         </dependency>
 
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -257,8 +256,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.18.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.reficio</groupId>
     <artifactId>p2-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>p2-maven-plugin</name>
     <url>https://github.com/reficio/p2-maven-plugin</url>
     <description>Maven plugin for the automation of jars wrapping and p2 site generation</description>

--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -184,7 +184,7 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
      * It defaults to false to keep the old behavior (ignoring bnd tool errors).
      */
     @Parameter(defaultValue = "true")
-    private boolean skipBndErrors;
+    private boolean ignoreBndErrors;
 
     /**
      * Dependency injection container - used to get some components programatically
@@ -530,7 +530,7 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
     }
 
     private ArtifactBundler getArtifactBundler() {
-        return new AquteBundler(pedantic, skipBndErrors);
+        return new AquteBundler(pedantic, ignoreBndErrors);
     }
 
     private void executeP2PublisherPlugin() throws IOException, MojoExecutionException {

--- a/src/main/java/org/reficio/p2/P2Mojo.java
+++ b/src/main/java/org/reficio/p2/P2Mojo.java
@@ -177,6 +177,16 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
     private String additionalArgs;
 
     /**
+     * Skipe coming from embedded bnd tools should be skipped.
+     *
+     * <p>
+     * This flag controls if the processing should be continued anyway, if the embedded bnd tool throws errors.
+     * It defaults to false to keep the old behavior (ignoring bnd tool errors).
+     */
+    @Parameter(defaultValue = "true")
+    private boolean skipBndErrors;
+
+    /**
      * Dependency injection container - used to get some components programatically
      */
     private PlexusContainer container;
@@ -520,7 +530,7 @@ public class P2Mojo extends AbstractMojo implements Contextualizable {
     }
 
     private ArtifactBundler getArtifactBundler() {
-        return new AquteBundler(pedantic);
+        return new AquteBundler(pedantic, skipBndErrors);
     }
 
     private void executeP2PublisherPlugin() throws IOException, MojoExecutionException {

--- a/src/main/java/org/reficio/p2/bundler/AquteAnalyzerException.java
+++ b/src/main/java/org/reficio/p2/bundler/AquteAnalyzerException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.p2.bundler;
+
+public class AquteAnalyzerException extends RuntimeException {
+    public AquteAnalyzerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
+++ b/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
@@ -49,16 +49,16 @@ public class AquteBundler implements ArtifactBundler {
 
     protected final BundleUtils bundleUtils;
     private final boolean pedantic;
-    private final boolean skipBndErrors;
+    private final boolean ignoreBndErrors;
 
-    public AquteBundler(boolean pedantic, boolean skipBndErrors) {
-        this.skipBndErrors = skipBndErrors;
+    public AquteBundler(boolean pedantic, boolean ignoreBndErrors) {
+        this.ignoreBndErrors = ignoreBndErrors;
         this.bundleUtils = new BundleUtils();
         this.pedantic = pedantic;
     }
 
-    AquteBundler(boolean pedantic, boolean skipBndErrors, BundleUtils bundleUtils) {
-        this.skipBndErrors = skipBndErrors;
+    AquteBundler(boolean pedantic, boolean ignoreBndErrors, BundleUtils bundleUtils) {
+        this.ignoreBndErrors = ignoreBndErrors;
         this.bundleUtils = bundleUtils;
         this.pedantic = pedantic;
     }
@@ -100,7 +100,7 @@ public class AquteBundler implements ArtifactBundler {
     private void handleVanillaJarWrap(ArtifactBundlerRequest request, ArtifactBundlerInstructions instructions) throws Exception {
         try (Analyzer analyzer = AquteHelper.buildAnalyzer(request, instructions, pedantic)) {
             populateJar(analyzer, request.getBinaryOutputFile());
-            if (bundleUtils.reportErrors(analyzer) && !skipBndErrors) {
+            if (bundleUtils.reportErrors(analyzer) && !ignoreBndErrors) {
                 throw new AquteAnalyzerException("Aqute Jar Analyser reports error.");
             }
             removeSignature(request.getBinaryOutputFile());

--- a/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
+++ b/src/main/java/org/reficio/p2/bundler/impl/AquteBundler.java
@@ -49,13 +49,16 @@ public class AquteBundler implements ArtifactBundler {
 
     protected final BundleUtils bundleUtils;
     private final boolean pedantic;
+    private final boolean skipBndErrors;
 
-    public AquteBundler(boolean pedantic) {
+    public AquteBundler(boolean pedantic, boolean skipBndErrors) {
+        this.skipBndErrors = skipBndErrors;
         this.bundleUtils = new BundleUtils();
         this.pedantic = pedantic;
     }
 
-    AquteBundler(boolean pedantic, BundleUtils bundleUtils) {
+    AquteBundler(boolean pedantic, boolean skipBndErrors, BundleUtils bundleUtils) {
+        this.skipBndErrors = skipBndErrors;
         this.bundleUtils = bundleUtils;
         this.pedantic = pedantic;
     }
@@ -97,7 +100,7 @@ public class AquteBundler implements ArtifactBundler {
     private void handleVanillaJarWrap(ArtifactBundlerRequest request, ArtifactBundlerInstructions instructions) throws Exception {
         try (Analyzer analyzer = AquteHelper.buildAnalyzer(request, instructions, pedantic)) {
             populateJar(analyzer, request.getBinaryOutputFile());
-            if (bundleUtils.reportErrors(analyzer)) {
+            if (bundleUtils.reportErrors(analyzer) && !skipBndErrors) {
                 throw new AquteAnalyzerException("Aqute Jar Analyser reports error.");
             }
             removeSignature(request.getBinaryOutputFile());

--- a/src/test/integration/issue-241-it/invoker.properties
+++ b/src/test/integration/issue-241-it/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=p2:site
+invoker.buildResult=failure

--- a/src/test/integration/issue-241-it/pom.xml
+++ b/src/test/integration/issue-241-it/pom.xml
@@ -51,7 +51,7 @@
                     <execution>
                         <id>default-cli</id>
                         <configuration>
-                            <skipBndErrors>false</skipBndErrors>
+                            <ignoreBndErrors>false</ignoreBndErrors>
                             <artifacts>
                                 <artifact>
                                     <id>org.python:jython-standalone:2.5.3</id>

--- a/src/test/integration/issue-241-it/pom.xml
+++ b/src/test/integration/issue-241-it/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001 XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.reficio</groupId>
+        <artifactId>integration</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../integration.xml</relativePath>
+    </parent>
+
+    <artifactId>config</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <description>
+        Test the skip bnd error config option
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.reficio</groupId>
+                <artifactId>p2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <skipBndErrors>false</skipBndErrors>
+                            <artifacts>
+                                <artifact>
+                                    <id>org.python:jython-standalone:2.5.3</id>
+                                    <override>true</override>
+                                    <instructions>
+                                        <Eclipse-BundleShape>dir</Eclipse-BundleShape>
+                                        <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
+                                    </instructions>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/java/org/reficio/p2/bundler/impl/AnalyzerStub.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/AnalyzerStub.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.p2.bundler.impl;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
+
+import java.util.jar.Manifest;
+
+class AnalyzerStub extends Analyzer {
+    @Override
+    public Manifest calcManifest() throws Exception {
+        return new Manifest();
+    }
+
+    @Override
+    public Jar getJar() {
+        return new Jar("fake");
+    }
+}

--- a/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
@@ -21,6 +21,7 @@ package org.reficio.p2.bundler.impl;
 
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.assertj.core.api.ThrowableAssert;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
@@ -42,6 +43,11 @@ public class AquteBundlerTest {
     @BeforeClass
     public static void setUpClass() {
         Logger.initialize(new SystemStreamLog());
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        Logger.initialize(null);
     }
 
     @Test

--- a/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
@@ -50,10 +50,22 @@ public class AquteBundlerTest {
             theMock.when(() -> AquteHelper.buildAnalyzer(any(ArtifactBundlerRequest.class), any(ArtifactBundlerInstructions.class), anyBoolean()))
                     .thenReturn(new AnalyzerStub());
 
-            AquteBundler bundlerUnderTest = new AquteBundler(true, new BundleUtilsStub());
+            AquteBundler bundlerUnderTest = new AquteBundler(true, false, new BundleUtilsStub());
             ThrowableAssert.ThrowingCallable methodUnderTest = () -> bundlerUnderTest.execute(new ArtifactBundlerRequest(new File(""), new File("target/tmp.jar"), null, null, true), ArtifactBundlerInstructions.builder().build());
 
             assertThatThrownBy(methodUnderTest).isInstanceOf(RuntimeException.class).hasRootCauseInstanceOf(AquteAnalyzerException.class);
+        }
+    }
+
+    @Test
+    public void bndAnalyzerProduceErrorThenExceptionIsUnexpected() {
+        try (MockedStatic<AquteHelper> theMock = mockStatic(AquteHelper.class)) {
+            theMock.when(() -> AquteHelper.buildAnalyzer(any(ArtifactBundlerRequest.class), any(ArtifactBundlerInstructions.class), anyBoolean()))
+                    .thenReturn(new AnalyzerStub());
+
+            AquteBundler bundlerUnderTest = new AquteBundler(true, true, new BundleUtilsStub());
+
+            bundlerUnderTest.execute(new ArtifactBundlerRequest(new File(""), new File("target/tmp.jar"), null, null, true), ArtifactBundlerInstructions.builder().build());
         }
     }
 }

--- a/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.p2.bundler.impl;
+
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.reficio.p2.bundler.AquteAnalyzerException;
+import org.reficio.p2.bundler.ArtifactBundlerInstructions;
+import org.reficio.p2.bundler.ArtifactBundlerRequest;
+import org.reficio.p2.logger.Logger;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mockStatic;
+
+public class AquteBundlerTest {
+
+
+    @BeforeClass
+    public static void setUpClass() {
+        Logger.initialize(new SystemStreamLog());
+    }
+
+    @Test
+    public void bndAnalyzerProduceErrorThenExceptionIsExpected() {
+        try (MockedStatic<AquteHelper> theMock = mockStatic(AquteHelper.class)) {
+            theMock.when(() -> AquteHelper.buildAnalyzer(any(ArtifactBundlerRequest.class), any(ArtifactBundlerInstructions.class), anyBoolean()))
+                    .thenReturn(new AnalyzerStub());
+
+            AquteBundler bundlerUnderTest = new AquteBundler(true, new BundleUtilsStub());
+            ThrowableAssert.ThrowingCallable methodUnderTest = () -> bundlerUnderTest.execute(new ArtifactBundlerRequest(new File(""), new File("target/tmp.jar"), null, null, true), ArtifactBundlerInstructions.builder().build());
+
+            assertThatThrownBy(methodUnderTest).isInstanceOf(RuntimeException.class).hasRootCauseInstanceOf(AquteAnalyzerException.class);
+        }
+    }
+}

--- a/src/test/java/org/reficio/p2/bundler/impl/BundleUtilsStub.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/BundleUtilsStub.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2012 Reficio (TM) - Reestablish your software! All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.p2.bundler.impl;
+
+import aQute.bnd.osgi.Analyzer;
+import org.reficio.p2.utils.BundleUtils;
+
+class BundleUtilsStub extends BundleUtils {
+
+    @Override
+    public boolean reportErrors(Analyzer analyzer) {
+        return true;
+    }
+}


### PR DESCRIPTION
In the first draft bnd errors result in an exception. It seems according to an IT-test, that in some case a bnd error doesn't result in an inconsistent P2 repo (see bug18-it).

Idea: introduce a new parameter `ignoringBndError` with default value `true`to be backward compatible.