### PR TITLE
Migrate to JUnit Jupiter through OpenRewrite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,23 +266,29 @@
             <version>4.7.3</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.21.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Required by target/generated-sources/groovy-stubs/test  -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/reficio/p2/P2ArtifactTest.java
+++ b/src/test/java/org/reficio/p2/P2ArtifactTest.java
@@ -18,21 +18,21 @@
  */
 package org.reficio.p2;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @since 1.4.0
  */
-public class P2ArtifactTest {
+class P2ArtifactTest {
 
     @Test
-    public void testCombinedInstructions() {
+    void testCombinedInstructions() {
         // GIVEN
         P2Artifact artifact = new P2Artifact();
         artifact.setInstructions(Collections.singletonMap("Import-Package", "package.one"));
@@ -50,7 +50,7 @@ public class P2ArtifactTest {
     }
 
     @Test
-    public void testInstructionsPropertiesOverrideInstructions() {
+    void testInstructionsPropertiesOverrideInstructions() {
         // GIVEN
         P2Artifact artifact = new P2Artifact();
         artifact.setInstructions(Collections.singletonMap("Export-Package", "package.one"));
@@ -67,7 +67,7 @@ public class P2ArtifactTest {
     }
 
     @Test
-    public void testInstructionsPropertiesOverrideInstructionsWhenPropertiesSetFirst() {
+    void testInstructionsPropertiesOverrideInstructionsWhenPropertiesSetFirst() {
         // GIVEN
         P2Artifact artifact = new P2Artifact();
         Properties instructionsProperties = new Properties();

--- a/src/test/java/org/reficio/p2/bundler/ArtifactBundlerInstructionTest.java
+++ b/src/test/java/org/reficio/p2/bundler/ArtifactBundlerInstructionTest.java
@@ -18,9 +18,9 @@
  */
 package org.reficio.p2.bundler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.reficio.p2.P2Helper.calculateSourceName;
 
 /**
@@ -29,10 +29,10 @@ import static org.reficio.p2.P2Helper.calculateSourceName;
  *         http://www.reficio.org
  * @since 1.0.0
  */
-public class ArtifactBundlerInstructionTest {
+class ArtifactBundlerInstructionTest {
 
     @Test
-    public void calculateSourceName_specTest() {
+    void calculateSourceName_specTest() {
         assertEquals("org.reficio.p2.source", calculateSourceName(null, "org.reficio.p2"));
         assertEquals("org.reficio.P2.source", calculateSourceName(null, "org.reficio.P2"));
         assertEquals("Reficio P2 Source", calculateSourceName("Reficio P2", "org.reficio.p2"));

--- a/src/test/java/org/reficio/p2/bundler/ArtifactBundlerInstructionsTest.java
+++ b/src/test/java/org/reficio/p2/bundler/ArtifactBundlerInstructionsTest.java
@@ -18,17 +18,17 @@
  */
 package org.reficio.p2.bundler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class ArtifactBundlerInstructionsTest {
+class ArtifactBundlerInstructionsTest {
 
     @Test
-    public void useDefaultInstruction(){
+    void useDefaultInstruction() {
         ArtifactBundlerInstructions artifactBundlerInstructions = ArtifactBundlerInstructions.builder().build();
 
         assertThat(artifactBundlerInstructions.getInstructions())
@@ -39,7 +39,7 @@ public class ArtifactBundlerInstructionsTest {
     }
 
     @Test
-    public void ignoreDefaultInstruction(){
+    void ignoreDefaultInstruction() {
         ArtifactBundlerInstructions artifactBundlerInstructions = ArtifactBundlerInstructions.builder()
                 .instructions(Collections.singletonMap("-noee", "true"))
                 .build();

--- a/src/test/java/org/reficio/p2/bundler/P2ArtifactMapTest.java
+++ b/src/test/java/org/reficio/p2/bundler/P2ArtifactMapTest.java
@@ -18,17 +18,17 @@
  */
 package org.reficio.p2.bundler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reficio.p2.P2Artifact;
 
 import java.util.Collection;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class P2ArtifactMapTest {
+class P2ArtifactMapTest {
 
     @Test
-    public void getNoFoundValueReturnsEmptyList() {
+    void getNoFoundValueReturnsEmptyList() {
         P2ArtifactMap<P2Artifact> mapUnderTest = new P2ArtifactMap<>();
 
         Collection<P2Artifact> value = mapUnderTest.get(new P2Artifact());

--- a/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
+++ b/src/test/java/org/reficio/p2/bundler/impl/AquteBundlerTest.java
@@ -22,9 +22,9 @@ package org.reficio.p2.bundler.impl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.reficio.p2.bundler.AquteAnalyzerException;
 import org.reficio.p2.bundler.ArtifactBundlerInstructions;
@@ -39,21 +39,21 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mockStatic;
 
 @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
-public class AquteBundlerTest {
+class AquteBundlerTest {
 
 
-    @BeforeClass
-    public static void setUpClass() {
+    @BeforeAll
+    static void setUpClass() {
         Logger.initialize(new SystemStreamLog());
     }
 
-    @AfterClass
-    public static void cleanUp() {
+    @AfterAll
+    static void cleanUp() {
         Logger.initialize(null);
     }
 
     @Test
-    public void bndAnalyzerProduceErrorThenExceptionIsExpected() {
+    void bndAnalyzerProduceErrorThenExceptionIsExpected() {
         try (MockedStatic<AquteHelper> theMock = mockStatic(AquteHelper.class)) {
             theMock.when(() -> AquteHelper.buildAnalyzer(any(ArtifactBundlerRequest.class), any(ArtifactBundlerInstructions.class), anyBoolean()))
                     .thenReturn(new AnalyzerStub());
@@ -66,7 +66,7 @@ public class AquteBundlerTest {
     }
 
     @Test
-    public void bndAnalyzerProduceErrorThenExceptionIsUnexpected() {
+    void bndAnalyzerProduceErrorThenExceptionIsUnexpected() {
         try (MockedStatic<AquteHelper> theMock = mockStatic(AquteHelper.class)) {
             theMock.when(() -> AquteHelper.buildAnalyzer(any(ArtifactBundlerRequest.class), any(ArtifactBundlerInstructions.class), anyBoolean()))
                     .thenReturn(new AnalyzerStub());

--- a/src/test/java/org/reficio/p2/logger/LoggerTest.java
+++ b/src/test/java/org/reficio/p2/logger/LoggerTest.java
@@ -18,7 +18,9 @@
  */
 package org.reficio.p2.logger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Tom Bujok (tom.bujok@gmail.com)<br>
@@ -26,11 +28,13 @@ import org.junit.Test;
  *         http://www.reficio.org
  * @since 1.0.0
  */
-public class LoggerTest {
+class LoggerTest {
 
-    @Test(expected = RuntimeException.class)
-    public void getLog_uninitializedLogger_exceptionThrown() {
-        Logger.getLog();
+    @Test
+    void getLog_uninitializedLogger_exceptionThrown() {
+        assertThrows(RuntimeException.class, () -> {
+            Logger.getLog();
+        });
     }
 
 }

--- a/src/test/java/org/reficio/p2/publisher/CategoryPublisherTest.java
+++ b/src/test/java/org/reficio/p2/publisher/CategoryPublisherTest.java
@@ -21,13 +21,14 @@ package org.reficio.p2.publisher;
 import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.eclipse.sisu.equinox.launching.internal.P2ApplicationLauncher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
@@ -36,44 +37,54 @@ import static org.mockito.Mockito.when;
  *         http://www.reficio.org
  * @since 1.0.0
  */
-public class CategoryPublisherTest {
+class CategoryPublisherTest {
 
-    @Test(expected = NullPointerException.class)
-    public void nullLauncher() {
-        CategoryPublisher.builder().p2ApplicationLauncher(null);
+    @Test
+    void nullLauncher() {
+        assertThrows(NullPointerException.class, () -> {
+            CategoryPublisher.builder().p2ApplicationLauncher(null);
+        });
     }
 
-    @Test(expected = NullPointerException.class)
-    public void emptyBuilder() {
-        CategoryPublisher.builder().build();
+    @Test
+    void emptyBuilder() {
+        assertThrows(NullPointerException.class, () -> {
+            CategoryPublisher.builder().build();
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void wrongTimeout() {
-        CategoryPublisher.builder().forkedProcessTimeoutInSeconds(-1);
+    @Test
+    void wrongTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            CategoryPublisher.builder().forkedProcessTimeoutInSeconds(-1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void wrongArgs() {
-        CategoryPublisher.builder().additionalArgs("--zcx.vzxc.v§';s.dcxz-1-aods[vzmcxvlkzndofahsdpf");
+    @Test
+    void wrongArgs() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            CategoryPublisher.builder().additionalArgs("--zcx.vzxc.v§';s.dcxz-1-aods[vzmcxvlkzndofahsdpf");
+        });
     }
 
-    @Test(expected = MojoFailureException.class)
-    public void exceptionThrownInCaseOfLauncherFailure() throws IOException, AbstractMojoExecutionException {
-        // given
-        P2ApplicationLauncher launcher = Mockito.mock(P2ApplicationLauncher.class, Mockito.RETURNS_DEEP_STUBS);
-        when(launcher.execute(Mockito.anyInt())).thenReturn(137);
-        File file = File.createTempFile(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        file.deleteOnExit();
+    @Test
+    void exceptionThrownInCaseOfLauncherFailure() throws IOException, AbstractMojoExecutionException {
+        assertThrows(MojoFailureException.class, () -> {
+            // given
+            P2ApplicationLauncher launcher = Mockito.mock(P2ApplicationLauncher.class, Mockito.RETURNS_DEEP_STUBS);
+            when(launcher.execute(Mockito.anyInt())).thenReturn(137);
+            File file = File.createTempFile(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            file.deleteOnExit();
 
-        // when
-        CategoryPublisher publisher = CategoryPublisher.builder()
-                .p2ApplicationLauncher(launcher)
-                .categoryFileLocation(file.getPath())
-                .additionalArgs("-args")
-                .metadataRepositoryLocation("target/tmp")
-                .build();
-        publisher.execute();
+            // when
+            CategoryPublisher publisher = CategoryPublisher.builder()
+                    .p2ApplicationLauncher(launcher)
+                    .categoryFileLocation(file.getPath())
+                    .additionalArgs("-args")
+                    .metadataRepositoryLocation("target/tmp")
+                    .build();
+            publisher.execute();
+        });
     }
 
 }

--- a/src/test/java/org/reficio/p2/resolver/impl/AetherTest.java
+++ b/src/test/java/org/reficio/p2/resolver/impl/AetherTest.java
@@ -18,15 +18,13 @@
  */
 package org.reficio.p2.resolver.impl;
 
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reficio.p2.resolver.maven.impl.Aether;
 import org.reficio.p2.resolver.maven.impl.facade.AetherEclipseFacade;
 import org.reficio.p2.resolver.maven.impl.facade.AetherFacade;
 import org.reficio.p2.resolver.maven.impl.facade.AetherSonatypeFacade;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -35,10 +33,10 @@ import static org.mockito.Mockito.mock;
  *         http://www.reficio.org
  * @since 1.1.0
  */
-public class AetherTest {
+class AetherTest {
 
     @Test
-    public void facade_sonatypeAetherSystem() {
+    void facade_sonatypeAetherSystem() {
         // GIVEN
         Object repositorySystem = mock(org.sonatype.aether.RepositorySystem.class);
 
@@ -50,7 +48,7 @@ public class AetherTest {
     }
 
     @Test
-    public void facade_eclipseAetherSystem() {
+    void facade_eclipseAetherSystem() {
         // GIVEN
         Object repositorySystem = mock(org.eclipse.aether.RepositorySystem.class);
 

--- a/src/test/java/org/reficio/p2/utils/BundleUtilsTest.java
+++ b/src/test/java/org/reficio/p2/utils/BundleUtilsTest.java
@@ -20,8 +20,8 @@ package org.reficio.p2.utils;
 
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Jar;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -30,8 +30,8 @@ import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,17 +41,17 @@ import static org.mockito.Mockito.when;
  *         http://www.reficio.org
  * @since 1.0.0
  */
-public class BundleUtilsTest {
+class BundleUtilsTest {
 
     private BundleUtils utils;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         utils = new BundleUtils();
     }
 
     @Test
-    public void isBundle_nonExistingJar() {
+    void isBundle_nonExistingJar() {
         // given
         Jar jar = new Jar("non-existing.jar");
 
@@ -63,7 +63,7 @@ public class BundleUtilsTest {
     }
 
     @Test
-    public void isBundle_cannotOpenManifest() throws Exception {
+    void isBundle_cannotOpenManifest() throws Exception {
         // given
         Jar jar = mock(Jar.class, Mockito.RETURNS_DEEP_STUBS);
         when(jar.getManifest()).thenThrow(new IOException());
@@ -76,7 +76,7 @@ public class BundleUtilsTest {
     }
 
     @Test
-    public void isBundle_emptyManifest() throws Exception {
+    void isBundle_emptyManifest() throws Exception {
         // given
         Jar jar = mock(Jar.class, Mockito.RETURNS_DEEP_STUBS);
         when(jar.getManifest().getMainAttributes()).thenReturn(null);
@@ -89,7 +89,7 @@ public class BundleUtilsTest {
     }
 
     @Test
-    public void isBundle_manifestWithAttributes() throws Exception {
+    void isBundle_manifestWithAttributes() throws Exception {
         // given
         Jar jar = mock(Jar.class, Mockito.RETURNS_DEEP_STUBS);
         when(jar.getManifest().getMainAttributes().getValue(any(Attributes.Name.class))).thenReturn("org.apache.commons");
@@ -102,21 +102,23 @@ public class BundleUtilsTest {
     }
 
     @Test
-    public void newManifest_hasMainAttributes() {
+    void newManifest_hasMainAttributes() {
         assertNotNull(new Manifest().getMainAttributes());
     }
 
-    @Test(expected = RuntimeException.class)
-    public void isBundle_nonExistingFile() {
-        // given
-        File file = new File(UUID.randomUUID().toString());
+    @Test
+    void isBundle_nonExistingFile() {
+        assertThrows(RuntimeException.class, () -> {
+            // given
+            File file = new File(UUID.randomUUID().toString());
 
-        // when
-        utils.isBundle(file);
+            // when
+            utils.isBundle(file);
+        });
     }
 
     @Test
-    public void getBundleName_correctBundleNameFromMainAttribuets() throws Exception {
+    void getBundleName_correctBundleNameFromMainAttribuets() throws Exception {
         // given
         String bundleName = "org.reficio.example.bundle";
         Jar jar = mock(Jar.class, Mockito.RETURNS_DEEP_STUBS);


### PR DESCRIPTION
Fixes #296.

Had to still add the vintage-engine manually for the generated groovy stubs. Have not explored the options there; you might want to see if there's a newer generator now that JUnit Jupiter is used and remove the vintage-engine again.

Otherwise automatically migrated through:
```bash
mvn org.openrewrite.maven:rewrite-maven-plugin:4.39.0:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:1.33.0 \
  -DactiveRecipes=org.openrewrite.java.testing.junit5.JUnit5BestPractices
```

If you still want to try out OpenRewrite/Moderne there's a few more suggested recipes to apply:
https://public.moderne.io/recipes/org.openrewrite.java.testing.assertj.Assertj
https://public.moderne.io/recipes/org.openrewrite.java.testing.junit5.UseMockitoExtension

You might need to [create a repository group](https://public.moderne.io/settings/repo-groups) first, only containing:
https://public.moderne.io/organizations/reficio/p2-maven-plugin?branch=master
Happy to walk you through it if needed, although it's [also documented here](https://docs.moderne.io/user-documentation/running-your-first-recipe).